### PR TITLE
Dont repeat names 6.2.2

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -22,6 +22,17 @@ sourceSets.main {
     }
 }
 
+sourceSets.test {
+    java {
+        srcDir "$projectDir/test"
+    }
+}
+
+test {
+    useJUnitPlatform()
+    maxHeapSize = '1G'
+}
+
 jar {
     manifest.from 'src/META-INF/MANIFEST.MF'
 }
@@ -29,4 +40,7 @@ jar {
 
 dependencies {
     compile "com.google.code.gson:gson:${gsonVersion}"
+    testImplementation "org.junit.jupiter:junit-jupiter:${jupiterVersion}"
+    testImplementation "org.junit.jupiter:junit-jupiter-api:${jupiterVersion}"
+    testImplementation "org.junit.jupiter:junit-jupiter-engine:${jupiterVersion}"
 }

--- a/core/gradle.properties
+++ b/core/gradle.properties
@@ -3,3 +3,4 @@
 target = 1.8
 
 gsonVersion = 2.8.5
+jupiterVersion = 5.6.0

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -13,9 +13,11 @@
     </parent>
     <artifactId>proguard-base</artifactId>
     <name>[${project.groupId}] ${project.artifactId}</name>
+    <version>6.2.2.1</version>
 
     <build>
         <sourceDirectory>src</sourceDirectory>
+        <testSourceDirectory>test</testSourceDirectory>
         <plugins>
             <plugin>
                 <artifactId>maven-source-plugin</artifactId>
@@ -33,9 +35,11 @@
                     </archive>
                 </configuration>
             </plugin>
+<!--
             <plugin>
                 <artifactId>maven-javadoc-plugin</artifactId>
             </plugin>
+-->
         </plugins>
     </build>
 
@@ -45,6 +49,25 @@
             <artifactId>gson</artifactId>
             <version>2.8.5</version>
             <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.6.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>5.6.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>5.6.0</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
     <repositories>

--- a/core/src/proguard/Configuration.java
+++ b/core/src/proguard/Configuration.java
@@ -197,6 +197,21 @@ public class Configuration
     public boolean   obfuscate                        = true;
 
     /**
+     * Specifies whether package naming factory should reset for each package or not.
+     */
+    public boolean dontResetPackageNaming                 = false;
+
+    /**
+     * Specifies whether class naming factory should reset for each package or not.
+     */
+    public boolean dontResetClassNaming                   = false;
+
+    /**
+     * Specifies whether class member naming factory should reset for each package or not.
+     */
+    public boolean dontResetMemberNaming                   = false;
+
+    /**
      * An optional output file for listing the obfuscation mapping.
      * An empty file name means the standard output.
      */

--- a/core/src/proguard/ConfigurationConstants.java
+++ b/core/src/proguard/ConfigurationConstants.java
@@ -69,6 +69,9 @@ class ConfigurationConstants
     public static final String DONT_OBFUSCATE_OPTION                  = "-dontobfuscate";
     public static final String PRINT_MAPPING_OPTION                   = "-printmapping";
     public static final String APPLY_MAPPING_OPTION                   = "-applymapping";
+    public static final String DONT_RESET_PACKAGE_NAMING_OPTION       = "-dontresetpackagenaming";
+    public static final String DONT_RESET_CLASS_NAMING_OPTION         = "-dontresetclassnaming";
+    public static final String DONT_RESET_MEMBER_NAMING_OPTION        = "-dontresetmembernaming";
     public static final String OBFUSCATION_DICTIONARY_OPTION          = "-obfuscationdictionary";
     public static final String CLASS_OBFUSCATION_DICTIONARY_OPTION    = "-classobfuscationdictionary";
     public static final String PACKAGE_OBFUSCATION_DICTIONARY_OPTION  = "-packageobfuscationdictionary";

--- a/core/src/proguard/ConfigurationParser.java
+++ b/core/src/proguard/ConfigurationParser.java
@@ -191,6 +191,9 @@ public class ConfigurationParser
             else if (ConfigurationConstants.DONT_OBFUSCATE_OPTION                            .startsWith(nextWord)) configuration.obfuscate                             = parseNoArgument(false);
             else if (ConfigurationConstants.PRINT_MAPPING_OPTION                             .startsWith(nextWord)) configuration.printMapping                          = parseOptionalFile();
             else if (ConfigurationConstants.APPLY_MAPPING_OPTION                             .startsWith(nextWord)) configuration.applyMapping                          = parseFile();
+            else if (ConfigurationConstants.DONT_RESET_PACKAGE_NAMING_OPTION                 .startsWith(nextWord)) configuration.dontResetPackageNaming                = parseNoArgument(true);
+            else if (ConfigurationConstants.DONT_RESET_CLASS_NAMING_OPTION                   .startsWith(nextWord)) configuration.dontResetClassNaming                  = parseNoArgument(true);
+            else if (ConfigurationConstants.DONT_RESET_MEMBER_NAMING_OPTION                  .startsWith(nextWord)) configuration.dontResetMemberNaming                 = parseNoArgument(true);
             else if (ConfigurationConstants.OBFUSCATION_DICTIONARY_OPTION                    .startsWith(nextWord)) configuration.obfuscationDictionary                 = parseURL();
             else if (ConfigurationConstants.CLASS_OBFUSCATION_DICTIONARY_OPTION              .startsWith(nextWord)) configuration.classObfuscationDictionary            = parseURL();
             else if (ConfigurationConstants.PACKAGE_OBFUSCATION_DICTIONARY_OPTION            .startsWith(nextWord)) configuration.packageObfuscationDictionary          = parseURL();

--- a/core/src/proguard/ConfigurationWriter.java
+++ b/core/src/proguard/ConfigurationWriter.java
@@ -114,6 +114,9 @@ public class ConfigurationWriter
         writeOption(ConfigurationConstants.DONT_OBFUSCATE_OPTION,                            !configuration.obfuscate);
         writeOption(ConfigurationConstants.PRINT_MAPPING_OPTION,                             configuration.printMapping);
         writeOption(ConfigurationConstants.APPLY_MAPPING_OPTION,                             configuration.applyMapping);
+        writeOption(ConfigurationConstants.DONT_RESET_PACKAGE_NAMING_OPTION,                 !configuration.dontResetPackageNaming);
+        writeOption(ConfigurationConstants.DONT_RESET_CLASS_NAMING_OPTION,                   !configuration.dontResetClassNaming);
+        writeOption(ConfigurationConstants.DONT_RESET_MEMBER_NAMING_OPTION,                  !configuration.dontResetMemberNaming);
         writeOption(ConfigurationConstants.OBFUSCATION_DICTIONARY_OPTION,                    configuration.obfuscationDictionary);
         writeOption(ConfigurationConstants.CLASS_OBFUSCATION_DICTIONARY_OPTION,              configuration.classObfuscationDictionary);
         writeOption(ConfigurationConstants.PACKAGE_OBFUSCATION_DICTIONARY_OPTION,            configuration.packageObfuscationDictionary);

--- a/core/src/proguard/obfuscate/ClassObfuscator.java
+++ b/core/src/proguard/obfuscate/ClassObfuscator.java
@@ -50,6 +50,8 @@ implements   ClassVisitor,
     private final DictionaryNameFactory classNameFactory;
     private final DictionaryNameFactory packageNameFactory;
     private final boolean               useMixedCaseClassNames;
+    private final boolean               dontResetPackageNaming;
+    private final boolean               dontResetClassNaming;
     private final StringMatcher         keepPackageNamesMatcher;
     private final String                flattenPackageHierarchy;
     private final String                repackageClasses;
@@ -86,6 +88,10 @@ implements   ClassVisitor,
      *                                dictionary.
      * @param useMixedCaseClassNames  specifies whether obfuscated packages and
      *                                classes can get mixed-case names.
+     * @param dontResetPackageNaming  specifies whether package naming factory should be
+     *                                package level or root level for all packages.
+     * @param dontResetClassNaming    specifies whether class naming factory should be
+     *                                package level or root level for all classes.
      * @param keepPackageNames        the optional filter for which matching
      *                                package names are kept.
      * @param flattenPackageHierarchy the base package if the obfuscated package
@@ -100,6 +106,8 @@ implements   ClassVisitor,
                            DictionaryNameFactory classNameFactory,
                            DictionaryNameFactory packageNameFactory,
                            boolean               useMixedCaseClassNames,
+                           boolean               dontResetPackageNaming,
+                           boolean               dontResetClassNaming,
                            List                  keepPackageNames,
                            String                flattenPackageHierarchy,
                            String                repackageClasses,
@@ -123,6 +131,8 @@ implements   ClassVisitor,
         }
 
         this.useMixedCaseClassNames  = useMixedCaseClassNames;
+        this.dontResetPackageNaming  = dontResetPackageNaming;
+        this.dontResetClassNaming    = dontResetClassNaming;
         this.keepPackageNamesMatcher = keepPackageNames == null ? null :
             new ListParser(new FileNameParser()).parse(keepPackageNames);
         this.flattenPackageHierarchy = flattenPackageHierarchy;
@@ -403,7 +413,7 @@ implements   ClassVisitor,
     {
         // Find the right name factory for this package.
         NameFactory packageNameFactory =
-            (NameFactory)packagePrefixPackageNameFactoryMap.get(newSuperPackagePrefix);
+            (NameFactory)packagePrefixPackageNameFactoryMap.get((dontResetPackageNaming) ? "_" : newSuperPackagePrefix);
         if (packageNameFactory == null)
         {
             // We haven't seen packages in this superpackage before. Create
@@ -416,7 +426,7 @@ implements   ClassVisitor,
                                               packageNameFactory);
             }
 
-            packagePrefixPackageNameFactoryMap.put(newSuperPackagePrefix,
+            packagePrefixPackageNameFactoryMap.put((dontResetPackageNaming) ? "_" : newSuperPackagePrefix,
                                                    packageNameFactory);
         }
 
@@ -453,7 +463,7 @@ implements   ClassVisitor,
     {
         // Find the right name factory for this package.
         NameFactory classNameFactory =
-            (NameFactory)packagePrefixClassNameFactoryMap.get(newPackagePrefix);
+            (NameFactory)packagePrefixClassNameFactoryMap.get((dontResetClassNaming) ? "_" : newPackagePrefix);
         if (classNameFactory == null)
         {
             // We haven't seen classes in this package before.
@@ -466,7 +476,7 @@ implements   ClassVisitor,
                                               classNameFactory);
             }
 
-            packagePrefixClassNameFactoryMap.put(newPackagePrefix,
+            packagePrefixClassNameFactoryMap.put((dontResetClassNaming) ? "_" : newPackagePrefix,
                                                  classNameFactory);
         }
 
@@ -481,14 +491,14 @@ implements   ClassVisitor,
     {
         // Find the right name factory for this package.
         NameFactory classNameFactory =
-            (NameFactory)packagePrefixNumericClassNameFactoryMap.get(newPackagePrefix);
+            (NameFactory)packagePrefixNumericClassNameFactoryMap.get((dontResetClassNaming) ? "_" : newPackagePrefix);
         if (classNameFactory == null)
         {
             // We haven't seen classes in this package before.
             // Create a new name factory for them.
             classNameFactory = new NumericNameFactory();
 
-            packagePrefixNumericClassNameFactoryMap.put(newPackagePrefix,
+            packagePrefixNumericClassNameFactoryMap.put((dontResetClassNaming) ? "_" : newPackagePrefix,
                                                         classNameFactory);
         }
 

--- a/core/src/proguard/obfuscate/MemberObfuscator.java
+++ b/core/src/proguard/obfuscate/MemberObfuscator.java
@@ -42,6 +42,7 @@ extends      SimplifiedVisitor
 implements   MemberVisitor
 {
     private final boolean        allowAggressiveOverloading;
+    private final boolean        dontResetMemberNaming;
     private final NameFactory    nameFactory;
     private final Map            descriptorMap;
 
@@ -50,16 +51,20 @@ implements   MemberVisitor
      * Creates a new MemberObfuscator.
      * @param allowAggressiveOverloading a flag that specifies whether class
      *                                   members can be overloaded aggressively.
+     * @param dontResetMemberNaming      a flag that specifies whether to reset
+     *                                   naming factory for every new class or not.
      * @param nameFactory                the factory that can produce
      *                                   obfuscated member names.
      * @param descriptorMap              the map of descriptors to
      *                                   [new name - old name] maps.
      */
     public MemberObfuscator(boolean        allowAggressiveOverloading,
+                            boolean        dontResetMemberNaming,
                             NameFactory    nameFactory,
                             Map            descriptorMap)
     {
         this.allowAggressiveOverloading = allowAggressiveOverloading;
+        this.dontResetMemberNaming      = dontResetMemberNaming;
         this.nameFactory                = nameFactory;
         this.descriptorMap              = descriptorMap;
     }
@@ -98,7 +103,10 @@ implements   MemberVisitor
         if (newName == null)
         {
             // Find an acceptable new name.
-            nameFactory.reset();
+            if(!dontResetMemberNaming)
+            {
+                nameFactory.reset();
+            }
 
             do
             {

--- a/core/src/proguard/obfuscate/Obfuscator.java
+++ b/core/src/proguard/obfuscate/Obfuscator.java
@@ -232,6 +232,8 @@ public class Obfuscator
                                 classNameFactory,
                                 packageNameFactory,
                                 configuration.useMixedCaseClassNames,
+                                configuration.dontResetPackageNaming,
+                                configuration.dontResetClassNaming,
                                 configuration.keepPackageNames,
                                 configuration.flattenPackageHierarchy,
                                 configuration.repackageClasses,
@@ -264,6 +266,7 @@ public class Obfuscator
             programClassPool.classesAccept(
                 new AllMemberVisitor(
                 new MemberObfuscator(configuration.overloadAggressively,
+                                     configuration.dontResetMemberNaming,
                                      nameFactory,
                                      descriptorMap)));
         }
@@ -292,6 +295,7 @@ public class Obfuscator
                     new AllMemberVisitor(
                     new MemberAccessFilter(0, ClassConstants.ACC_PRIVATE,
                     new MemberObfuscator(configuration.overloadAggressively,
+                                         configuration.dontResetMemberNaming,
                                          nameFactory,
                                          descriptorMap))),
 
@@ -343,6 +347,7 @@ public class Obfuscator
                     new AllMemberVisitor(
                     new MemberAccessFilter(ClassConstants.ACC_PRIVATE, 0,
                     new MemberObfuscator(configuration.overloadAggressively,
+                                         configuration.dontResetMemberNaming,
                                          nameFactory,
                                          descriptorMap))),
 
@@ -400,6 +405,7 @@ public class Obfuscator
                                             descriptorMap,
                                             warningPrinter,
                 new MemberObfuscator(configuration.overloadAggressively,
+                                     configuration.dontResetMemberNaming,
                                      specialNameFactory,
                                      specialDescriptorMap))))),
 
@@ -431,6 +437,7 @@ public class Obfuscator
                                             descriptorMap,
                                             warningPrinter,
                 new MemberObfuscator(configuration.overloadAggressively,
+                                     configuration.dontResetMemberNaming,
                                      specialNameFactory,
                                      specialDescriptorMap)))),
 

--- a/core/test/proguard/ProGuardTest.java
+++ b/core/test/proguard/ProGuardTest.java
@@ -1,0 +1,45 @@
+package proguard;
+
+import org.junit.jupiter.api.Test;
+
+class ProGuardTest {
+
+    @Test
+    void main() {
+
+        String targetLocation = "\\";
+        String inputJar = "classes";
+        String outputJar = "proguardClasses";
+        String map_filename = "proguard_map.txt";
+        String seed_filename = "proguard_seed.txt";
+        String method_dir_filename = "method-dictionary.txt";
+        String class_dir_filename = "class-dictionary.txt";
+        String package_dir_filename = "package-dictionary.txt";
+
+        String [] arguments = {
+                "-dontshrink",
+                "-dontoptimize",
+                "-adaptclassstrings",
+                "-keepparameternames",
+                "-keep class com.study.BootWebApplication",
+                "-ignorewarnings",
+                "-injars '" + targetLocation + inputJar + "'",
+                "-outjars '" + targetLocation + outputJar + "'",
+                "-printmapping '" + targetLocation + map_filename + "'",
+                "-printseeds '" + targetLocation + seed_filename + "'",
+
+                "-dontresetmembernaming",
+                "-dontresetclassnaming",
+                "-dontresetpackagenaming",
+
+                "-obfuscationdictionary '" + targetLocation + method_dir_filename + "'",
+                "-classobfuscationdictionary '" + targetLocation + class_dir_filename + "'",
+                "-packageobfuscationdictionary '" + targetLocation + package_dir_filename + "'",
+
+                "-dontwarn java.lang.**",
+                "-dontwarn java.util.**"
+        };
+
+        ProGuard.main(arguments);
+    }
+}

--- a/core/test/proguard/ProGuardTest.java
+++ b/core/test/proguard/ProGuardTest.java
@@ -7,14 +7,17 @@ class ProGuardTest {
     @Test
     void main() {
 
+        // NOTE: Change targetLocation value here to the location where
+        // inputJar and all below required items are available / expected
         String targetLocation = "\\";
+
         String inputJar = "classes";
         String outputJar = "proguardClasses";
         String map_filename = "proguard_map.txt";
         String seed_filename = "proguard_seed.txt";
-        String method_dir_filename = "method-dictionary.txt";
-        String class_dir_filename = "class-dictionary.txt";
-        String package_dir_filename = "package-dictionary.txt";
+        String members_dir_filename = "members-dictionary.txt";
+        String classes_dir_filename = "classes-dictionary.txt";
+        String packages_dir_filename = "packages-dictionary.txt";
 
         String [] arguments = {
                 "-dontshrink",
@@ -28,13 +31,16 @@ class ProGuardTest {
                 "-printmapping '" + targetLocation + map_filename + "'",
                 "-printseeds '" + targetLocation + seed_filename + "'",
 
+                //  This option makes sure that the obfuscation will use all unique names for members
                 "-dontresetmembernaming",
+                //  This option makes sure that the obfuscation will use all unique names for classes
                 "-dontresetclassnaming",
+                //  This option makes sure that the obfuscation will use all unique names for packages
                 "-dontresetpackagenaming",
 
-                "-obfuscationdictionary '" + targetLocation + method_dir_filename + "'",
-                "-classobfuscationdictionary '" + targetLocation + class_dir_filename + "'",
-                "-packageobfuscationdictionary '" + targetLocation + package_dir_filename + "'",
+                "-obfuscationdictionary '" + targetLocation + members_dir_filename + "'",
+                "-classobfuscationdictionary '" + targetLocation + classes_dir_filename + "'",
+                "-packageobfuscationdictionary '" + targetLocation + packages_dir_filename + "'",
 
                 "-dontwarn java.lang.**",
                 "-dontwarn java.util.**"

--- a/core/test/proguard/ProGuardTest.java
+++ b/core/test/proguard/ProGuardTest.java
@@ -21,7 +21,7 @@ class ProGuardTest {
                 "-dontoptimize",
                 "-adaptclassstrings",
                 "-keepparameternames",
-                "-keep class com.study.BootWebApplication",
+                "-keep class com.study.Application",
                 "-ignorewarnings",
                 "-injars '" + targetLocation + inputJar + "'",
                 "-outjars '" + targetLocation + outputJar + "'",


### PR DESCRIPTION
This is a feature implementation to allow unique names by not repeating the name directory. Current behavior is resetting index of directory to 0 at the time of container package or class changes.
It is my humble request that you accept it.

**Use case:** Sometimes, project may get error if names of classes or members repeats though it is in different packages.

**Future Enhancement:** A Unique Name Generator can be implemented instead of using name-directory.