### PR TITLE
Add Java 14

### DIFF
--- a/core/src/proguard/classfile/ClassConstants.java
+++ b/core/src/proguard/classfile/ClassConstants.java
@@ -62,6 +62,8 @@ public class ClassConstants
     public static final int CLASS_VERSION_12_MINOR  = 0;
     public static final int CLASS_VERSION_13_MAJOR  = 57;
     public static final int CLASS_VERSION_13_MINOR  = 0;
+    public static final int CLASS_VERSION_14_MAJOR  = 58;
+    public static final int CLASS_VERSION_14_MINOR  = 0;
 
     public static final int CLASS_VERSION_1_0 = (CLASS_VERSION_1_0_MAJOR << 16) | CLASS_VERSION_1_0_MINOR;
     public static final int CLASS_VERSION_1_2 = (CLASS_VERSION_1_2_MAJOR << 16) | CLASS_VERSION_1_2_MINOR;
@@ -76,6 +78,7 @@ public class ClassConstants
     public static final int CLASS_VERSION_11  = (CLASS_VERSION_11_MAJOR  << 16) | CLASS_VERSION_11_MINOR;
     public static final int CLASS_VERSION_12  = (CLASS_VERSION_12_MAJOR  << 16) | CLASS_VERSION_12_MINOR;
     public static final int CLASS_VERSION_13  = (CLASS_VERSION_13_MAJOR  << 16) | CLASS_VERSION_13_MINOR;
+    public static final int CLASS_VERSION_14  = (CLASS_VERSION_14_MAJOR  << 16) | CLASS_VERSION_14_MINOR;
 
     public static final int ACC_PUBLIC       = 0x0001;
     public static final int ACC_PRIVATE      = 0x0002;

--- a/core/src/proguard/classfile/JavaConstants.java
+++ b/core/src/proguard/classfile/JavaConstants.java
@@ -48,6 +48,7 @@ public interface JavaConstants
     public static final String CLASS_VERSION_11        = "11";
     public static final String CLASS_VERSION_12        = "12";
     public static final String CLASS_VERSION_13        = "13";
+    public static final String CLASS_VERSION_14        = "14";
 
     public static final String ACC_PUBLIC       = "public";
     public static final String ACC_PRIVATE      = "private";

--- a/core/src/proguard/classfile/util/ClassUtil.java
+++ b/core/src/proguard/classfile/util/ClassUtil.java
@@ -110,6 +110,7 @@ public class ClassUtil
             externalClassVersion.equals(JavaConstants.CLASS_VERSION_11)  ? ClassConstants.CLASS_VERSION_11  :
             externalClassVersion.equals(JavaConstants.CLASS_VERSION_12)  ? ClassConstants.CLASS_VERSION_12  :
             externalClassVersion.equals(JavaConstants.CLASS_VERSION_13)  ? ClassConstants.CLASS_VERSION_13  :
+            externalClassVersion.equals(JavaConstants.CLASS_VERSION_14)  ? ClassConstants.CLASS_VERSION_14  :
                                                                            0;
     }
 
@@ -136,6 +137,7 @@ public class ClassUtil
             case ClassConstants.CLASS_VERSION_11:  return JavaConstants.CLASS_VERSION_11;
             case ClassConstants.CLASS_VERSION_12:  return JavaConstants.CLASS_VERSION_12;
             case ClassConstants.CLASS_VERSION_13:  return JavaConstants.CLASS_VERSION_13;
+            case ClassConstants.CLASS_VERSION_14:  return JavaConstants.CLASS_VERSION_14;
             default:                               return null;
         }
     }
@@ -149,14 +151,14 @@ public class ClassUtil
     public static void checkVersionNumbers(int internalClassVersion) throws UnsupportedOperationException
     {
         if (internalClassVersion < ClassConstants.CLASS_VERSION_1_0 ||
-            internalClassVersion > ClassConstants.CLASS_VERSION_13)
+            internalClassVersion > ClassConstants.CLASS_VERSION_14)
         {
             throw new UnsupportedOperationException("Unsupported version number ["+
                                                     internalMajorClassVersion(internalClassVersion)+"."+
                                                     internalMinorClassVersion(internalClassVersion)+"] (maximum "+
-                                                    ClassConstants.CLASS_VERSION_13_MAJOR+"."+
-                                                    ClassConstants.CLASS_VERSION_13_MINOR+", Java "+
-                                                    JavaConstants.CLASS_VERSION_13+")");
+                                                    ClassConstants.CLASS_VERSION_14_MAJOR+"."+
+                                                    ClassConstants.CLASS_VERSION_14_MINOR+", Java "+
+                                                    JavaConstants.CLASS_VERSION_14+")");
         }
     }
 


### PR DESCRIPTION
Proguard fails in the latest JDK due to this check.  I presume the list just hasn't been updated in a while, and not that there is a bona fide incompatibility, since nothing depended on this at compile time.  This change got proguard-maven-plugin working for me.