### PR TITLE
Add -dontcompress configuration option.

### DIFF
--- a/core/src/proguard/Configuration.java
+++ b/core/src/proguard/Configuration.java
@@ -367,9 +367,14 @@ public class Configuration
     public boolean   addConfigurationDebugging;
 
     /**
-     * Specifies whether to backporting of class files to another
+     * Specifies whether backporting of class files to another
      * targetClassVersion shall be enabled.
      */
     public boolean   backport                         = false;
+
+    /**
+     * Specifies whether to compress output archives.
+     */
+    public boolean   compress                         = true;
 
 }

--- a/core/src/proguard/ConfigurationConstants.java
+++ b/core/src/proguard/ConfigurationConstants.java
@@ -103,6 +103,7 @@ class ConfigurationConstants
     public static final String TARGET_OPTION                                     = "-target";
     public static final String KEEP_DIRECTORIES_OPTION                           = "-keepdirectories";
     public static final String FORCE_PROCESSING_OPTION                           = "-forceprocessing";
+    public static final String DONT_COMPRESS                                     = "-dontcompress";
 
 
     public static final String ANY_FILE_KEYWORD            = "**";

--- a/core/src/proguard/ConfigurationParser.java
+++ b/core/src/proguard/ConfigurationParser.java
@@ -160,6 +160,7 @@ public class ConfigurationParser
             else if (ConfigurationConstants.DONT_SKIP_NON_PUBLIC_LIBRARY_CLASS_MEMBERS_OPTION.startsWith(nextWord)) configuration.skipNonPublicLibraryClassMembers      = parseNoArgument(false);
             else if (ConfigurationConstants.TARGET_OPTION                                    .startsWith(nextWord)) configuration.targetClassVersion                    = parseClassVersion();
             else if (ConfigurationConstants.FORCE_PROCESSING_OPTION                          .startsWith(nextWord)) configuration.lastModified                          = parseNoArgument(Long.MAX_VALUE);
+            else if (ConfigurationConstants.DONT_COMPRESS                                    .startsWith(nextWord)) configuration.compress                              = parseNoArgument(false);
 
             else if (ConfigurationConstants.IF_OPTION                                        .startsWith(nextWord)) configuration.keep                                  = parseIfCondition(configuration.keep);
             else if (ConfigurationConstants.KEEP_OPTION                                      .startsWith(nextWord)) configuration.keep                                  = parseKeepClassSpecificationArguments(configuration.keep, true,  false, false, null);

--- a/core/src/proguard/DataEntryWriterFactory.java
+++ b/core/src/proguard/DataEntryWriterFactory.java
@@ -63,7 +63,8 @@ public class DataEntryWriterFactory
      */
     public DataEntryWriter createDataEntryWriter(ClassPath classPath,
                                                  int       fromIndex,
-                                                 int       toIndex)
+                                                 int       toIndex,
+                                                 boolean   compress)
     {
         DataEntryWriter writer = null;
 
@@ -72,7 +73,7 @@ public class DataEntryWriterFactory
         {
             ClassPathEntry entry = classPath.get(index);
 
-            writer = createClassPathEntryWriter(entry, writer);
+            writer = createClassPathEntryWriter(entry, writer, compress);
         }
 
         return writer;
@@ -84,7 +85,8 @@ public class DataEntryWriterFactory
      * or delegate to another DataEntryWriter if its filters don't match.
      */
     private DataEntryWriter createClassPathEntryWriter(ClassPathEntry  classPathEntry,
-                                                       DataEntryWriter alternativeWriter)
+                                                       DataEntryWriter alternativeWriter,
+                                                       boolean         compress)
     {
         boolean isApk  = classPathEntry.isApk();
         boolean isJar  = classPathEntry.isJar();
@@ -143,13 +145,13 @@ public class DataEntryWriterFactory
         boolean flattenZips  = flattenJmods || isJmod;
 
         // Set up the filtered jar writers.
-        writer = wrapInJarWriter(writer, flattenZips,  isZip,  ".zip",  zipFilter,  null,                       null);
-        writer = wrapInJarWriter(writer, flattenJmods, isJmod, ".jmod", jmodFilter, ClassConstants.JMOD_HEADER, ClassConstants.JMOD_CLASS_FILE_PREFIX);
-        writer = wrapInJarWriter(writer, flattenEars,  isEar,  ".ear",  earFilter,  null,                       null);
-        writer = wrapInJarWriter(writer, flattenWars,  isWar,  ".war",  warFilter,  null,                       ClassConstants.WAR_CLASS_FILE_PREFIX);
-        writer = wrapInJarWriter(writer, flattenAars,  isAar,  ".aar",  aarFilter,  null,                       null);
-        writer = wrapInJarWriter(writer, flattenJars,  isJar,  ".jar",  jarFilter,  null,                       null);
-        writer = wrapInJarWriter(writer, flattenApks,  isApk,  ".apk",  apkFilter,  null,                       null);
+        writer = wrapInJarWriter(writer, flattenZips,  isZip,  ".zip",  zipFilter,  null,                       null,                                  compress);
+        writer = wrapInJarWriter(writer, flattenJmods, isJmod, ".jmod", jmodFilter, ClassConstants.JMOD_HEADER, ClassConstants.JMOD_CLASS_FILE_PREFIX, compress);
+        writer = wrapInJarWriter(writer, flattenEars,  isEar,  ".ear",  earFilter,  null,                       null,                                  compress);
+        writer = wrapInJarWriter(writer, flattenWars,  isWar,  ".war",  warFilter,  null,                       ClassConstants.WAR_CLASS_FILE_PREFIX,  compress);
+        writer = wrapInJarWriter(writer, flattenAars,  isAar,  ".aar",  aarFilter,  null,                       null,                                  compress);
+        writer = wrapInJarWriter(writer, flattenJars,  isJar,  ".jar",  jarFilter,  null,                       null,                                  compress);
+        writer = wrapInJarWriter(writer, flattenApks,  isApk,  ".apk",  apkFilter,  null,                       null,                                  compress);
 
         // Set up for writing out the program classes.
         writer = new ClassDataEntryWriter(programClassPool, writer);
@@ -184,7 +186,8 @@ public class DataEntryWriterFactory
                                             String          jarFilterExtension,
                                             List            jarFilter,
                                             byte[]          jarHeader,
-                                            String          classFilePrefix)
+                                            String          classFilePrefix,
+                                            boolean         compress)
     {
         // Flatten jars or zip them up.
         DataEntryWriter jarWriter;
@@ -196,7 +199,7 @@ public class DataEntryWriterFactory
         else
         {
             // Pack the jar.
-            jarWriter = new JarWriter(jarHeader, writer);
+            jarWriter = new JarWriter(jarHeader, writer, compress);
 
             // Add a prefix for class files inside the jar, if specified.
             if (classFilePrefix != null)

--- a/core/src/proguard/OutputWriter.java
+++ b/core/src/proguard/OutputWriter.java
@@ -119,7 +119,8 @@ public class OutputWriter
             DataEntryWriter writer =
                 dataEntryWriterFactory.createDataEntryWriter(classPath,
                                                              fromOutputIndex,
-                                                             toOutputIndex);
+                                                             toOutputIndex,
+                                                             configuration.compress);
 
             if (configuration.addConfigurationDebugging)
             {

--- a/core/src/proguard/io/DataEntryCopier.java
+++ b/core/src/proguard/io/DataEntryCopier.java
@@ -153,7 +153,7 @@ public class DataEntryCopier implements DataEntryReader
                                                          outputIsZip);
 
             // Zip up any zips, if necessary.
-            DataEntryWriter zipWriter = new JarWriter(writer);
+            DataEntryWriter zipWriter = new JarWriter(writer, true);
             if (outputIsZip)
             {
                 // Always zip.
@@ -170,7 +170,7 @@ public class DataEntryCopier implements DataEntryReader
             }
 
             // Zip up any jmods, if necessary.
-            DataEntryWriter jmodWriter = new JarWriter(ClassConstants.JMOD_HEADER, writer);
+            DataEntryWriter jmodWriter = new JarWriter(ClassConstants.JMOD_HEADER, writer, true);
             if (outputIsJmod)
             {
                 // Always zip.
@@ -187,7 +187,7 @@ public class DataEntryCopier implements DataEntryReader
             }
 
             // Zip up any wars, if necessary.
-            DataEntryWriter warWriter = new JarWriter(writer);
+            DataEntryWriter warWriter = new JarWriter(writer, true);
             if (outputIsWar)
             {
                 // Always zip.
@@ -204,7 +204,7 @@ public class DataEntryCopier implements DataEntryReader
             }
 
             // Zip up any aars, if necessary.
-            DataEntryWriter aarWriter = new JarWriter(writer);
+            DataEntryWriter aarWriter = new JarWriter(writer, true);
             if (outputIsWar)
             {
                 // Always zip.
@@ -221,7 +221,7 @@ public class DataEntryCopier implements DataEntryReader
             }
 
             // Zip up any jars, if necessary.
-            DataEntryWriter jarWriter = new JarWriter(writer);
+            DataEntryWriter jarWriter = new JarWriter(writer, true);
             if (outputIsJar)
             {
                 // Always zip.
@@ -238,7 +238,7 @@ public class DataEntryCopier implements DataEntryReader
             }
 
             // Zip up any apks, if necessary.
-            DataEntryWriter apkWriter = new JarWriter(writer);
+            DataEntryWriter apkWriter = new JarWriter(writer, true);
             if (outputIsApk)
             {
                 // Always zip.

--- a/core/src/proguard/io/JarWriter.java
+++ b/core/src/proguard/io/JarWriter.java
@@ -33,6 +33,7 @@ import java.util.Date;
  */
 public class JarWriter implements DataEntryWriter
 {
+    private final boolean         compress;
     private final byte[]          header;
     private final int             modificationTime;
     private final DataEntryWriter dataEntryWriter;
@@ -46,9 +47,10 @@ public class JarWriter implements DataEntryWriter
      * @param dataEntryWriter the data entry writer that can provide
      *                        output streams for the jar/zip archives.
      */
-    public JarWriter(DataEntryWriter dataEntryWriter)
+    public JarWriter(DataEntryWriter dataEntryWriter,
+                     boolean         compress)
     {
-        this(null, dataEntryWriter);
+        this(null, dataEntryWriter, compress);
     }
 
 
@@ -59,9 +61,10 @@ public class JarWriter implements DataEntryWriter
      *                        output streams for the jar/zip archives.
      */
     public JarWriter(byte[]          header,
-                     DataEntryWriter dataEntryWriter)
+                     DataEntryWriter dataEntryWriter,
+                     boolean         compress)
     {
-        this(header, currentTime(), dataEntryWriter);
+        this(header, currentTime(), dataEntryWriter, compress);
     }
 
 
@@ -75,11 +78,13 @@ public class JarWriter implements DataEntryWriter
      */
     public JarWriter(byte[]          header,
                      int             modificationTime,
-                     DataEntryWriter dataEntryWriter)
+                     DataEntryWriter dataEntryWriter,
+                     boolean         compress)
     {
         this.header           = header;
         this.modificationTime = modificationTime;
         this.dataEntryWriter  = dataEntryWriter;
+        this.compress         = compress;
     }
 
 
@@ -135,7 +140,7 @@ public class JarWriter implements DataEntryWriter
 
         // Create a new zip entry.
         return currentZipOutput.createOutputStream(dataEntry.getName(),
-                                                   true,
+                                                   compress,
                                                    modificationTime);
     }
 


### PR DESCRIPTION
This adds a `-dontcompress` configuration option so output archives are not compressed. Builds that do further processing after Proguard have no need for Proguard to compress the output JAR, so it would be nice to be able to avoid it and save a little time.