### PR TITLE
Correct resolution strategy to handle the change of group-id

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,9 @@ project you can enable ProGuard instead of the default R8 compiler:
         ...
         configurations.all {
             resolutionStrategy {
-                force 'net.sf.proguard:proguard-gradle:7.0.0'
+                dependencySubstitution {
+                    substitute module('net.sf.proguard:proguard-gradle') with module('com.guardsquare:proguard-gradle:7.0.0')
+                }
             }
         }
     }

--- a/docs/md/manual/gradleplugin.md
+++ b/docs/md/manual/gradleplugin.md
@@ -13,7 +13,9 @@ project you can enable ProGuard instead of the default R8 compiler:
             ...
             configurations.all {
                 resolutionStrategy {
-                    force 'net.sf.proguard:proguard-gradle:7.0.0'
+                    dependencySubstitution {
+                        substitute module('net.sf.proguard:proguard-gradle') with module('com.guardsquare:proguard-gradle:7.0.0')
+                    }
                 }
             }
         }

--- a/examples/android/build.gradle
+++ b/examples/android/build.gradle
@@ -10,7 +10,9 @@ buildscript {
         resolutionStrategy {
             // Override the default version of ProGuard
             // with the most recent one.
-            force 'net.sf.proguard:proguard-gradle:7.0.0'
+            dependencySubstitution {
+                substitute module('net.sf.proguard:proguard-gradle') with module('com.guardsquare:proguard-gradle:7.0.0')
+            }
         }
     }
 }


### PR DESCRIPTION
Things to consider:

- Rule will have to be changed when AGP use the new group-id
- Does not cover the case when customer wants to inject his own proguard-gradle build
- Not compatible with cli composite build (artifact-id discrepancy)

This patch is IMO enough for the 7.0.0 release.