### PR TITLE
Remove proguard-parent Maven artifact

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,6 @@
 plugins {
     id 'com.jfrog.bintray'
     id 'distribution'
-    id 'maven-publish'
     id 'signing'
 }
 
@@ -26,6 +25,22 @@ allprojects { Project project ->
                     create(project.name, MavenPublication) {
                         pom {
                             name = "$group:$artifactId"
+                            url = 'https://www.guardsquare.com/proguard'
+                            licenses {
+                                license {
+                                    name = 'GNU General Public License, Version 2'
+                                    url = 'https://www.gnu.org/licenses/gpl-2.0.txt'
+                                    distribution = 'repo'
+                                }
+                            }
+                            issueManagement {
+                                system = 'Github Tracker'
+                                url = 'https://github.com/Guardsquare/proguard/issues'
+                            }
+                            scm {
+                                url = 'https://github.com/Guardsquare/proguard.git'
+                                connection = 'scm:git:https://github.com/Guardsquare/proguard.git'
+                            }
                             developers {
                                 developer {
                                     id = 'lafortune'
@@ -104,8 +119,7 @@ allprojects { Project project ->
         if (pluginManager.hasPlugin('com.jfrog.bintray') && pluginManager.hasPlugin('maven-publish')) {
             configure(project) {
                 bintray {
-                    Publication rootPub = rootProject.publishing.publications.parent
-                    Publication pub = project.publishing.publications.getByName(project.name)
+                    Publication pub = publishing.publications.getByName(project.name)
                     user = findProperty('PROGUARD_BINTRAY_USER')
                     key = findProperty('PROGUARD_BINTRAY_KEY')
                     publications = [project.name]
@@ -116,42 +130,15 @@ allprojects { Project project ->
                         name = "$project.group:$pub.artifactId"
                         desc = pub.artifactId
                         licenses = ['GPL-2.0']
-                        websiteUrl = rootPub.pom.url.get()
-                        issueTrackerUrl = rootPub.pom.issueManagement.url.get()
-                        vcsUrl = rootPub.pom.scm.url.get()
+                        websiteUrl = pub.pom.url.get()
+                        issueTrackerUrl = pub.pom.issueManagement.url.get()
+                        vcsUrl = pub.pom.scm.url.get()
                         version {
                             name = project.version
                             gpg.sign = true
                             released = new Date()
                         }
                     }
-                }
-            }
-        }
-    }
-}
-
-publishing {
-    publications {
-        parent {
-            artifactId = "proguard-parent"
-            pom {
-                description = 'ProGuard is a free Java class file shrinker, optimizer, obfuscator, and preverifier.'
-                url = 'https://www.guardsquare.com/proguard'
-                licenses {
-                    license {
-                        name = 'GNU General Public License, Version 2'
-                        url = 'https://www.gnu.org/licenses/gpl-2.0.txt'
-                        distribution = 'repo'
-                    }
-                }
-                issueManagement {
-                    system = 'Github Tracker'
-                    url = 'https://github.com/Guardsquare/proguard/issues'
-                }
-                scm {
-                    url = 'https://github.com/Guardsquare/proguard.git'
-                    connection = 'scm:git:https://github.com/Guardsquare/proguard.git'
                 }
             }
         }

--- a/settings.gradle
+++ b/settings.gradle
@@ -16,7 +16,7 @@ if (hasProperty('proguardCoreDir'))
     includeBuild proguardCoreDir
 }
 
-rootProject.name = 'parent'
+rootProject.name = 'proguard'
 
 include 'base'
 include 'retrace'


### PR DESCRIPTION
This pull request is mainly about removing the `proguard-parent` Maven publication.

Several reasons:

- JCenter does not accept jar-less packages
- The publication contains no useful content except for license, issue and scm POM elements
- Name is not specific enough and can be confusing wrt the `base` publication 