### PR TITLE
Fix ProGuard html manual link

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ inlining methods, propagating constants, removing unused parameters, etc.
   without needing the source code at all!
 
 The manual pages ([markdown](docs/md),
-[html](https://www.guardsquare.com/proguard/manual)) cover the features and usage of
+[html](https://www.guardsquare.com/en/products/proguard/manual)) cover the features and usage of
 ProGuard in detail.
 
 ## 🤝 Contributing


### PR DESCRIPTION
Fix ProGuard html manual link (current link says 404 not found)