### PR TITLE
Fix writing of kept directories

### DIFF
--- a/base/src/proguard/OutputWriter.java
+++ b/base/src/proguard/OutputWriter.java
@@ -390,8 +390,10 @@ public class OutputWriter
     private DataEntryWriter renameResourceFiles(ResourceFilePool resourceFilePool,
                                                 DataEntryWriter  dataEntryWriter)
     {
-        return new RenamedDataEntryWriter(new ResourceFilePoolNameFunction(resourceFilePool),
-                                          dataEntryWriter);
+        return new FilteredDataEntryWriter(new DataEntryDirectoryFilter(),
+                   dataEntryWriter,
+                   new RenamedDataEntryWriter(new ResourceFilePoolNameFunction(resourceFilePool),
+                                              dataEntryWriter));
     }
 
 

--- a/docs/md/releasenotes.md
+++ b/docs/md/releasenotes.md
@@ -2,6 +2,7 @@
 
 | Version| Issue    | Module   | Explanation
 |--------|----------|----------|----------------------------------
+| 7.1.x  | PGD-0110 | CORE     | Fixed writing of kept directories.
 | 7.1.x  | PGC-0015 | CORE     | Added support for Java 16.
 | 7.1.x  | PGD-0064 | CORE     | Added support for Java 14 and 15.
 | 7.1.x  | PGD-0064 | CORE     | Added support for sealed classes (permitted subclasses attributes).


### PR DESCRIPTION
Avoids wrapping directories in a `RenamedDataEntryWriter` since directories are not in the resource file pool which had meant the `ResourceFilePoolNameFunction` always returned null for directories.

Closes: #110