### PR TITLE
Add cache relocatability to proguard task.

### DIFF
--- a/examples/spring-boot/build.gradle
+++ b/examples/spring-boot/build.gradle
@@ -45,12 +45,12 @@ task deleteClasses(type: Delete) {
 task copyObfuscatedClasses(type: Copy) {
     dependsOn tasks.deleteClasses
 
-    from "${buildDir}/obfuscatedClasses"
+    from zipTree("${buildDir}/obfuscatedClasses.jar")
     into "${buildDir}/extracted/BOOT-INF/classes/"
 }
 
 task deleteObfuscated(type: Delete) {
-    delete 'build/obfuscatedClasses'
+    delete 'build/obfuscatedClasses.jar'
 }
 
 task repackage(type: Zip) {

--- a/examples/spring-boot/build.gradle
+++ b/examples/spring-boot/build.gradle
@@ -70,7 +70,7 @@ task proguard(type: ProGuardTask) {
     verbose
 
     injars  "${buildDir}/extracted/BOOT-INF/classes"
-    outjars "${buildDir}/obfuscatedClasses"
+    outjars "${buildDir}/obfuscatedClasses.jar"
 
     // Automatically handle the Java version of this build.
     if (System.getProperty('java.version').startsWith('1.')) {

--- a/gradle-plugin/build.gradle
+++ b/gradle-plugin/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'com.jfrog.bintray'
-    id 'java-library'
+    id 'java-gradle-plugin'
     id 'groovy'
     id 'maven-publish'
 }
@@ -63,11 +63,11 @@ repositories {
 }
 
 dependencies {
-    compile project(':base')
-    compile 'com.guardsquare:proguard-core'
+    implementation project(':base')
+    implementation 'com.guardsquare:proguard-core'
     compileOnly 'com.android.tools.build:gradle:3.0.0'
-    compile gradleApi()
-    compile localGroovy()
+    compileOnly gradleApi()
+    implementation localGroovy()
     testImplementation gradleTestKit()
     testImplementation 'junit:junit:4.13.1'
     testImplementation "org.spockframework:spock-core:1.1-groovy-2.4@jar"

--- a/gradle-plugin/src/proguard/gradle/ProGuardTask.java
+++ b/gradle-plugin/src/proguard/gradle/ProGuardTask.java
@@ -24,14 +24,12 @@ import groovy.lang.Closure;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.file.*;
 import org.gradle.api.logging.*;
-import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.tasks.*;
 import proguard.*;
 import proguard.classfile.*;
 import proguard.classfile.util.ClassUtil;
 import proguard.util.ListUtil;
 
-import javax.inject.Inject;
 import java.io.*;
 import java.net.*;
 import java.util.*;

--- a/gradle-plugin/src/proguard/gradle/ProGuardTask.java
+++ b/gradle-plugin/src/proguard/gradle/ProGuardTask.java
@@ -44,13 +44,6 @@ import java.util.*;
 @CacheableTask
 public abstract class ProGuardTask extends DefaultTask
 {
-
-    @Inject
-    public abstract ProjectLayout getProjectLayout();
-
-    @Inject
-    public abstract ObjectFactory getObjectFactory();
-
     // Accumulated input and output, for the sake of Gradle's lazy file
     // resolution and lazy task execution.
     private final List          inJarFiles         = new ArrayList();
@@ -86,7 +79,7 @@ public abstract class ProGuardTask extends DefaultTask
     @OutputFiles
     protected FileCollection getOutJarFileCollection()
     {
-        return getObjectFactory().fileCollection().from(getProject().files(outJarFiles).builtBy(this));
+        return getProject().files(outJarFiles);
     }
 
     @Classpath

--- a/gradle-plugin/test/proguard/gradle/GradlePluginIntegrationTest.groovy
+++ b/gradle-plugin/test/proguard/gradle/GradlePluginIntegrationTest.groovy
@@ -15,12 +15,15 @@ class GradlePluginIntegrationTest extends Specification {
         def projectRoot = temporaryFolder.newFolder()
         def fixture = new File(getClass().classLoader.getResource('spring-boot').path)
         FileUtils.copyDirectory(fixture, projectRoot)
+        TestPluginClasspath.applyToRootGradle(projectRoot)
 
         when:
         def result = GradleRunner.create()
-                .forwardOutput().withArguments('proguard')
-                .withProjectDir(projectRoot)
-                .build()
+            .forwardOutput()
+            .withArguments('proguard')
+            .withPluginClasspath()
+            .withProjectDir(projectRoot)
+            .build()
 
         then:
         result.output =~ "SUCCESSFUL"

--- a/gradle-plugin/test/proguard/gradle/GradlePluginIntegrationTest.groovy
+++ b/gradle-plugin/test/proguard/gradle/GradlePluginIntegrationTest.groovy
@@ -18,11 +18,12 @@ class GradlePluginIntegrationTest extends Specification {
 
         when:
         def result = GradleRunner.create()
-        .forwardOutput().withArguments('proguard')
-        .withProjectDir(projectRoot)
-        .build()
+                .forwardOutput().withArguments('proguard')
+                .withProjectDir(projectRoot)
+                .build()
 
         then:
         result.output =~ "SUCCESSFUL"
     }
 }
+

--- a/gradle-plugin/test/proguard/gradle/ProguardCacheRelocateabilityIntegrationTest.groovy
+++ b/gradle-plugin/test/proguard/gradle/ProguardCacheRelocateabilityIntegrationTest.groovy
@@ -15,15 +15,16 @@ class ProguardCacheRelocateabilityIntegrationTest extends Specification {
     @Unroll
     def "proguard task can be relocated"() {
         def cacheDir = cacheFolder.newFolder()
-        def originalDir = temporaryFolder.newFolder()
         def fixture = new File(getClass().classLoader.getResource('spring-boot').path)
+
+        def originalDir = temporaryFolder.newFolder()
         FileUtils.copyDirectory(fixture, originalDir)
-        writeBuildGradle(originalDir)
+        TestPluginClasspath.applyToRootGradle(originalDir)
         writeSettingsGradle(originalDir, cacheDir)
 
         def relocatedDir = temporaryFolder.newFolder()
         FileUtils.copyDirectory(fixture, relocatedDir)
-        writeBuildGradle(relocatedDir)
+        TestPluginClasspath.applyToRootGradle(relocatedDir)
         writeSettingsGradle(relocatedDir, cacheDir)
 
         when:
@@ -51,112 +52,6 @@ class ProguardCacheRelocateabilityIntegrationTest extends Specification {
                 local(DirectoryBuildCache) {
                     directory = "${cacheDir.absolutePath.replace(File.separatorChar, '/' as char)}"
                 }
-            }
-            """.stripIndent()
-    }
-
-    def writeBuildGradle(def projectDir) {
-        new File(projectDir, 'build.gradle').text = """
-            import proguard.gradle.ProGuardTask
-            
-            plugins {
-              id 'org.springframework.boot' version '2.3.5.RELEASE'
-              id 'io.spring.dependency-management' version '1.0.10.RELEASE'
-              id 'java'
-              id 'proguard' apply false
-            }
-            
-            group = 'com.example'
-            version = '0.0.1'
-            sourceCompatibility = '1.8'
-            
-            repositories {
-              mavenCentral()
-            }
-            
-            dependencies {
-              implementation 'org.springframework.boot:spring-boot-starter'
-            }
-            
-            task extractJar(type: Copy) {
-                dependsOn tasks.assemble
-            
-                def zipFile = file("\${buildDir}/libs/demo-\${version}.jar")
-                def outputDir = file("\${buildDir}/extracted/")
-            
-                from zipTree(zipFile)
-                into outputDir
-            }
-            
-            task deleteClasses(type: Delete) {
-                delete "\${buildDir}/extracted/BOOT-INF/classes/"
-            }
-            
-            task copyObfuscatedClasses(type: Copy) {
-                dependsOn tasks.deleteClasses
-            
-                from "\${buildDir}/obfuscatedClasses"
-                into "\${buildDir}/extracted/BOOT-INF/classes/"
-            }
-            
-            task deleteObfuscated(type: Delete) {
-                delete 'build/obfuscatedClasses'
-            }
-            
-            task repackage(type: Zip) {
-                dependsOn tasks.deleteClasses
-                dependsOn tasks.copyObfuscatedClasses
-                dependsOn tasks.deleteObfuscated
-            
-                from  "\${buildDir}/extracted"
-                entryCompression ZipEntryCompression.STORED
-                archiveName "demo-\$version-obfuscated.jar"
-                destinationDir(file("\${buildDir}/libs"))
-            }
-            
-            task proguard(type: ProGuardTask) {
-                dependsOn tasks.extractJar
-            
-                verbose
-            
-                injars  "\${buildDir}/extracted/BOOT-INF/classes"
-                outjars "\${buildDir}/obfuscatedClasses.jar"
-            
-                // Automatically handle the Java version of this build.
-                if (System.getProperty('java.version').startsWith('1.')) {
-                    // Before Java 9, the runtime classes were packaged in a single jar file.
-                    libraryjars "\${System.getProperty('java.home')}/lib/rt.jar"
-                } else {
-                    // As of Java 9, the runtime classes are packaged in modular jmod files.
-                    libraryjars "\${System.getProperty('java.home')}/jmods/java.base.jmod", jarfilter: '!**.jar', filter: '!module-info.class'
-                    //libraryjars "\${System.getProperty('java.home')}/jmods/....."
-                }
-            
-                // This will contain the Spring dependencies.
-                libraryjars sourceSets.main.compileClasspath
-            
-                keepdirectories
-            
-                // Keep the main class entry point.
-                keep 'public class com.example.demo.DemoApplication { \\
-                        public static void main(java.lang.String[]); \\
-                     }'
-            
-                keepattributes '*Annotation*'
-            
-                // This simple example requires classes with @Component annotation classes
-                // to be kept, since otherwise components could end up with clashing names,
-                // if they do not set the name explicitly.
-                keep 'public @org.springframework.stereotype.Component class *'
-            
-                // You may need to keep classes or members based on other annotations such as:
-                keepclassmembers 'public class * { \\
-                        @org.springframework.beans.factory.annotation.Autowired *; \\
-                        @org.springframework.beans.factory.annotation.Value *; \\
-                    }'
-            
-                // After ProGuard has executed, repackage the app.
-                finalizedBy tasks.repackage
             }
             """.stripIndent()
     }

--- a/gradle-plugin/test/proguard/gradle/ProguardCacheRelocateabilityIntegrationTest.groovy
+++ b/gradle-plugin/test/proguard/gradle/ProguardCacheRelocateabilityIntegrationTest.groovy
@@ -1,0 +1,164 @@
+package proguard.gradle
+
+import org.apache.commons.io.FileUtils
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class ProguardCacheRelocateabilityIntegrationTest extends Specification {
+    @Rule TemporaryFolder temporaryFolder
+    @Rule TemporaryFolder cacheFolder
+
+    @Unroll
+    def "proguard task can be relocated"() {
+        def cacheDir = cacheFolder.newFolder()
+        def originalDir = temporaryFolder.newFolder()
+        def fixture = new File(getClass().classLoader.getResource('spring-boot').path)
+        FileUtils.copyDirectory(fixture, originalDir)
+        writeBuildGradle(originalDir)
+        writeSettingsGradle(originalDir, cacheDir)
+
+        def relocatedDir = temporaryFolder.newFolder()
+        FileUtils.copyDirectory(fixture, relocatedDir)
+        writeBuildGradle(relocatedDir)
+        writeSettingsGradle(relocatedDir, cacheDir)
+
+        when:
+        def result = GradleRunner.create()
+            .forwardOutput()
+            .withArguments('proguard', '--build-cache')
+            .withPluginClasspath()
+            .withProjectDir(originalDir)
+            .build()
+
+        def result2 = GradleRunner.create()
+            .forwardOutput()
+            .withArguments('proguard', '--build-cache')
+            .withPluginClasspath()
+            .withProjectDir(relocatedDir)
+            .build()
+        then:
+        result.output =~ "SUCCESSFUL"
+        result2.output =~ "SUCCESSFUL"
+        result2.output =~ "Task :proguard FROM-CACHE"
+    }
+
+    def writeSettingsGradle(def projectDir, def cacheDir) {
+        new File(projectDir, "settings.gradle").text = """
+            rootProject.name = 'demo'
+            buildCache {
+                local(DirectoryBuildCache) {
+                    directory = "${cacheDir.absolutePath.replace(File.separatorChar, '/' as char)}"
+                }
+            }
+            """.stripIndent()
+    }
+
+    def writeBuildGradle(def projectDir) {
+        new File(projectDir, 'build.gradle').text = """
+            import proguard.gradle.ProGuardTask
+            
+            plugins {
+              id 'org.springframework.boot' version '2.3.5.RELEASE'
+              id 'io.spring.dependency-management' version '1.0.10.RELEASE'
+              id 'java'
+              id 'proguard' apply false
+            }
+            
+            group = 'com.example'
+            version = '0.0.1'
+            sourceCompatibility = '1.8'
+            
+            repositories {
+              mavenCentral()
+            }
+            
+            dependencies {
+              implementation 'org.springframework.boot:spring-boot-starter'
+            }
+            
+            task extractJar(type: Copy) {
+                dependsOn tasks.assemble
+            
+                def zipFile = file("\${buildDir}/libs/demo-\${version}.jar")
+                def outputDir = file("\${buildDir}/extracted/")
+            
+                from zipTree(zipFile)
+                into outputDir
+            }
+            
+            task deleteClasses(type: Delete) {
+                delete "\${buildDir}/extracted/BOOT-INF/classes/"
+            }
+            
+            task copyObfuscatedClasses(type: Copy) {
+                dependsOn tasks.deleteClasses
+            
+                from "\${buildDir}/obfuscatedClasses"
+                into "\${buildDir}/extracted/BOOT-INF/classes/"
+            }
+            
+            task deleteObfuscated(type: Delete) {
+                delete 'build/obfuscatedClasses'
+            }
+            
+            task repackage(type: Zip) {
+                dependsOn tasks.deleteClasses
+                dependsOn tasks.copyObfuscatedClasses
+                dependsOn tasks.deleteObfuscated
+            
+                from  "\${buildDir}/extracted"
+                entryCompression ZipEntryCompression.STORED
+                archiveName "demo-\$version-obfuscated.jar"
+                destinationDir(file("\${buildDir}/libs"))
+            }
+            
+            task proguard(type: ProGuardTask) {
+                dependsOn tasks.extractJar
+            
+                verbose
+            
+                injars  "\${buildDir}/extracted/BOOT-INF/classes"
+                outjars "\${buildDir}/obfuscatedClasses.jar"
+            
+                // Automatically handle the Java version of this build.
+                if (System.getProperty('java.version').startsWith('1.')) {
+                    // Before Java 9, the runtime classes were packaged in a single jar file.
+                    libraryjars "\${System.getProperty('java.home')}/lib/rt.jar"
+                } else {
+                    // As of Java 9, the runtime classes are packaged in modular jmod files.
+                    libraryjars "\${System.getProperty('java.home')}/jmods/java.base.jmod", jarfilter: '!**.jar', filter: '!module-info.class'
+                    //libraryjars "\${System.getProperty('java.home')}/jmods/....."
+                }
+            
+                // This will contain the Spring dependencies.
+                libraryjars sourceSets.main.compileClasspath
+            
+                keepdirectories
+            
+                // Keep the main class entry point.
+                keep 'public class com.example.demo.DemoApplication { \\
+                        public static void main(java.lang.String[]); \\
+                     }'
+            
+                keepattributes '*Annotation*'
+            
+                // This simple example requires classes with @Component annotation classes
+                // to be kept, since otherwise components could end up with clashing names,
+                // if they do not set the name explicitly.
+                keep 'public @org.springframework.stereotype.Component class *'
+            
+                // You may need to keep classes or members based on other annotations such as:
+                keepclassmembers 'public class * { \\
+                        @org.springframework.beans.factory.annotation.Autowired *; \\
+                        @org.springframework.beans.factory.annotation.Value *; \\
+                    }'
+            
+                // After ProGuard has executed, repackage the app.
+                finalizedBy tasks.repackage
+            }
+            """.stripIndent()
+    }
+}

--- a/gradle-plugin/test/proguard/gradle/ProguardCacheRelocateabilityIntegrationTest.groovy
+++ b/gradle-plugin/test/proguard/gradle/ProguardCacheRelocateabilityIntegrationTest.groovy
@@ -2,6 +2,7 @@ package proguard.gradle
 
 import org.apache.commons.io.FileUtils
 import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
 import spock.lang.Specification
@@ -40,9 +41,7 @@ class ProguardCacheRelocateabilityIntegrationTest extends Specification {
             .withProjectDir(relocatedDir)
             .build()
         then:
-        result.output =~ "SUCCESSFUL"
-        result2.output =~ "SUCCESSFUL"
-        result2.output =~ "Task :proguard FROM-CACHE"
+        result2.task(':proguard').outcome == TaskOutcome.FROM_CACHE
     }
 
     def writeSettingsGradle(def projectDir, def cacheDir) {

--- a/gradle-plugin/test/proguard/gradle/TestPluginClasspath.groovy
+++ b/gradle-plugin/test/proguard/gradle/TestPluginClasspath.groovy
@@ -1,0 +1,15 @@
+package proguard.gradle
+
+class TestPluginClasspath {
+
+    /**
+     * Replaces the buildscript block in the root build.gradle file with nothing and applies the proguard plugin
+     * in the plugins block.
+     * @param projectDir the root project dir where the build.gradle file is located
+     */
+    static void applyToRootGradle(def projectDir) {
+        def buildGradle = new File(projectDir, 'build.gradle')
+        buildGradle.text = buildGradle.text.replaceAll("(?ms)buildscript\\s+\\{.*?^\\}", '')
+                .replaceAll("id 'java'", "id 'java'\n    id 'proguard' apply false")
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -17,6 +17,7 @@ if (hasProperty('proguardCoreDir'))
 }
 
 rootProject.name = 'parent'
+
 include 'base'
 include 'retrace'
 include 'gui'

--- a/settings.gradle
+++ b/settings.gradle
@@ -17,7 +17,6 @@ if (hasProperty('proguardCoreDir'))
 }
 
 rootProject.name = 'parent'
-
 include 'base'
 include 'retrace'
 include 'gui'


### PR DESCRIPTION
This allows the Proguard Task to take advantage of the Gradle Build cache and re-use outputs from other builds.

This also adds a simple test for cache relocateability

This also marks properties and `@Internal` so that they do not show as build warnings.