### PR TITLE
Only log informational output when running with `verbose=true`

### DIFF
--- a/base/src/proguard/DataEntryReaderFactory.java
+++ b/base/src/proguard/DataEntryReaderFactory.java
@@ -43,6 +43,7 @@ public class DataEntryReaderFactory
 
 
     private final boolean android;
+    private final boolean verbose;
 
 
     /**
@@ -51,25 +52,13 @@ public class DataEntryReaderFactory
      * @param android Specifies whether the packaging is targeted at the
      *                Android platform. Archives inside the assets directory
      *                then aren't unpacked but simply read as data files.
+     * @param verbose Specifies if verbose messages should be emitted when
+     *                creating the DataEntryReader.
      */
-    public DataEntryReaderFactory(boolean android)
+    public DataEntryReaderFactory(boolean android, boolean verbose)
     {
         this.android = android;
-    }
-
-
-    /**
-     * Creates a DataEntryReader that can read the given class path entry.
-     *
-     * @param classPathEntry the input class path entry.
-     * @param reader         a data entry reader to which the reading of actual
-     *                       classes and resource files can be delegated.
-     * @return a DataEntryReader for reading the given class path entry.
-     */
-    public DataEntryReader createDataEntryReader(ClassPathEntry  classPathEntry,
-                                                 DataEntryReader reader)
-    {
-        return createDataEntryReader("", classPathEntry, reader, null);
+        this.verbose = verbose;
     }
 
     /**
@@ -84,25 +73,6 @@ public class DataEntryReaderFactory
     public DataEntryReader createDataEntryReader(String          messagePrefix,
                                                  ClassPathEntry  classPathEntry,
                                                  DataEntryReader reader)
-    {
-        return createDataEntryReader(messagePrefix, classPathEntry, reader, System.out);
-    }
-
-
-    /**
-     * Creates a DataEntryReader that can read the given class path entry.
-     *
-     * @param messagePrefix  a prefix for messages that are printed out.
-     * @param classPathEntry the input class path entry.
-     * @param reader         a data entry reader to which the reading of actual
-     *                       classes and resource files can be delegated.
-     * @param out            an optional print stream for messages.
-     * @return a DataEntryReader for reading the given class path entry.
-     */
-    public DataEntryReader createDataEntryReader(String          messagePrefix,
-                                                 ClassPathEntry  classPathEntry,
-                                                 DataEntryReader reader,
-                                                 PrintStream     out)
     {
         boolean isApk  = classPathEntry.isApk();
         boolean isAab  = classPathEntry.isAab();
@@ -123,9 +93,9 @@ public class DataEntryReaderFactory
         List jmodFilter = classPathEntry.getJmodFilter();
         List zipFilter  = classPathEntry.getZipFilter();
 
-        if (out != null)
+        if (verbose)
         {
-            out.println(messagePrefix +
+            System.out.println(messagePrefix +
                            (isApk  ? "apk"  :
                             isAab  ? "aab"  :
                             isJar  ? "jar"  :

--- a/base/src/proguard/DataEntryWriterFactory.java
+++ b/base/src/proguard/DataEntryWriterFactory.java
@@ -64,6 +64,7 @@ public class DataEntryWriterFactory
     private final boolean                    pageAlignNativeLibs;
     private final boolean                    mergeBundleJars;
     private final KeyStore.PrivateKeyEntry[] privateKeyEntries;
+    private final boolean                    verbose;
 
     private Map<File,DataEntryWriter> jarWriterCache = new HashMap();
 
@@ -86,6 +87,8 @@ public class DataEntryWriterFactory
      *                              in an Android app bundle into a
      *                              single jar.
      * @param privateKeyEntries     optional private keys to sign jars.
+     * @param verbose               specifies if verbose messages should be emitted when
+     *                              creating the DataEntryWriter.
      */
     public DataEntryWriterFactory(ClassPool                  programClassPool,
                                   ResourceFilePool           resourceFilePool,
@@ -94,7 +97,8 @@ public class DataEntryWriterFactory
                                   int                        uncompressedAlignment,
                                   boolean                    pageAlignNativeLibs,
                                   boolean                    mergeBundleJars,
-                                  KeyStore.PrivateKeyEntry[] privateKeyEntries)
+                                  KeyStore.PrivateKeyEntry[] privateKeyEntries,
+                                  boolean                    verbose)
     {
         this.programClassPool      = programClassPool;
         this.resourceFilePool      = resourceFilePool;
@@ -104,6 +108,7 @@ public class DataEntryWriterFactory
         this.pageAlignNativeLibs   = pageAlignNativeLibs;
         this.mergeBundleJars       = mergeBundleJars;
         this.privateKeyEntries     = privateKeyEntries;
+        this.verbose = verbose;
     }
 
 
@@ -209,28 +214,30 @@ public class DataEntryWriterFactory
         List jmodFilter = classPathEntry.getJmodFilter();
         List zipFilter  = classPathEntry.getZipFilter();
 
-        System.out.println("Preparing " +
-                           (privateKeyEntries == null ? "" : "signed ") +
-                           "output " +
-                           (isApk  ? "apk"  :
-                            isAab  ? "aab"  :
-                            isJar  ? "jar"  :
-                            isAar  ? "aar"  :
-                            isWar  ? "war"  :
-                            isEar  ? "ear"  :
-                            isJmod ? "jmod" :
-                            isZip  ? "zip"  :
-                                     "directory") +
-                           " [" + classPathEntry.getName() + "]" +
-                           (filter     != null ||
-                            apkFilter  != null ||
-                            aabFilter  != null ||
-                            jarFilter  != null ||
-                            aarFilter  != null ||
-                            warFilter  != null ||
-                            earFilter  != null ||
-                            jmodFilter != null ||
-                            zipFilter  != null ? " (filtered)" : ""));
+        if (verbose) {
+            System.out.println("Preparing " +
+                               (privateKeyEntries == null ? "" : "signed ") +
+                               "output " +
+                               (isApk  ? "apk"  :
+                                isAab  ? "aab"  :
+                                isJar  ? "jar"  :
+                                isAar  ? "aar"  :
+                                isWar  ? "war"  :
+                                isEar  ? "ear"  :
+                                isJmod ? "jmod" :
+                                isZip  ? "zip"  :
+                                         "directory") +
+                               " [" + classPathEntry.getName() + "]" +
+                               (filter     != null ||
+                                apkFilter  != null ||
+                                aabFilter  != null ||
+                                jarFilter  != null ||
+                                aarFilter  != null ||
+                                warFilter  != null ||
+                                earFilter  != null ||
+                                jmodFilter != null ||
+                                zipFilter  != null ? " (filtered)" : ""));
+        }
 
         // Create the writer for the main file or directory.
         DataEntryWriter writer =

--- a/base/src/proguard/InputReader.java
+++ b/base/src/proguard/InputReader.java
@@ -245,7 +245,7 @@ public class InputReader
         {
             // Create a reader that can unwrap jars, wars, ears, jmods and zips.
             DataEntryReader reader =
-                new DataEntryReaderFactory(configuration.android)
+                new DataEntryReaderFactory(configuration.android, configuration.verbose)
                     .createDataEntryReader(messagePrefix,
                                            classPathEntry,
                                            dataEntryReader);

--- a/base/src/proguard/OutputWriter.java
+++ b/base/src/proguard/OutputWriter.java
@@ -96,7 +96,8 @@ public class OutputWriter
                                        configuration.zipAlign,
                                        configuration.android, //resourceInfo.pageAlignNativeLibs,
                                        configuration.obfuscate,
-                                       privateKeyEntries);
+                                       privateKeyEntries,
+                                       configuration.verbose);
 
         int firstInputIndex = 0;
         int lastInputIndex  = 0;


### PR DESCRIPTION
The `DataEntryReaderFactory` and `DataEntryWriterFactory` were both writing informational messages to `stdout` in a way that made these messages difficult to suppress. 

With this change, these messages are only displayed when the `verbose` setting is enabled on the Proguard configuration.

I considered using `java.util.logging` for this task, but the Proguard codebase makes extensive use of `System.out.println` for message and using a logger felt inconsistent. Moving these messages to verbose mode felt like the best approach.

Fixes #29 