### PR TITLE
Fix gradle plugin double publication

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,79 +17,95 @@ task buildDocumentation(type: Exec) {
     args '-c', "docker run --volume $rootDir/docs:/docs --rm squidfunk/mkdocs-material:5.2.2 build"
 }
 
+// Add repositories
 allprojects { Project project ->
-    pluginManager.withPlugin('maven-publish') {
-        configure(project) {
-            publishing {
-                publications {
-                    create(project.name, MavenPublication) {
-                        pom {
-                            name = "$group:$artifactId"
-                            url = 'https://www.guardsquare.com/proguard'
-                            licenses {
-                                license {
-                                    name = 'GNU General Public License, Version 2'
-                                    url = 'https://www.gnu.org/licenses/gpl-2.0.txt'
-                                    distribution = 'repo'
-                                }
+    afterEvaluate {
+        if (pluginManager.hasPlugin('maven-publish')) {
+            configure(project) {
+                publishing {
+                    repositories {
+                        maven {
+                            name = 'Github'
+                            url = uri('https://maven.pkg.github.com/guardsquare/proguard')
+                            credentials {
+                                username = project.findProperty('PROGUARD_GITHUB_USERNAME')
+                                password = project.findProperty('PROGUARD_GITHUB_TOKEN')
                             }
-                            issueManagement {
-                                system = 'Github Tracker'
-                                url = 'https://github.com/Guardsquare/proguard/issues'
-                            }
-                            scm {
-                                url = 'https://github.com/Guardsquare/proguard.git'
-                                connection = 'scm:git:https://github.com/Guardsquare/proguard.git'
-                            }
-                            developers {
-                                developer {
-                                    id = 'lafortune'
-                                    name = 'Eric Lafortune'
-                                    organization = 'Guardsquare'
-                                    organizationUrl = 'https://www.guardsquare.com/'
-                                    roles = ['Project Administrator', 'Developer']
-                                }
+                        }
+                        maven {
+                            name = 'Sonatype'
+                            url = 'https://oss.sonatype.org/service/local/staging/deploy/maven2'
+                            credentials(PasswordCredentials) {
+                                username = findProperty('PROGUARD_STAGING_USERNAME')
+                                password = findProperty('PROGUARD_STAGING_PASSWORD')
                             }
                         }
                     }
                 }
-                repositories {
-                    maven {
-                        name = 'Github'
-                        url = uri('https://maven.pkg.github.com/guardsquare/proguard')
-                        credentials {
-                            username = project.findProperty('PROGUARD_GITHUB_USERNAME')
-                            password = project.findProperty('PROGUARD_GITHUB_TOKEN')
-                        }
+                if (hasProperty('PROGUARD_SIGNING_KEY')) {
+                    // We use in-memory ascii-armored keys
+                    // See https://docs.gradle.org/current/userguide/signing_plugin.html#sec:in-memory-keys
+                    signing {
+                        String key = findProperty('PROGUARD_SIGNING_KEY')
+                        String password = findProperty('PROGUARD_SIGNING_PASSWORD')
+                        useInMemoryPgpKeys(key, password)
+                        sign publishing.publications.getByName(project.name)
                     }
-                    maven {
-                        name = 'Sonatype'
-                        url = 'https://oss.sonatype.org/service/local/staging/deploy/maven2'
-                        credentials(PasswordCredentials) {
-                            username = findProperty('PROGUARD_STAGING_USERNAME')
-                            password = findProperty('PROGUARD_STAGING_PASSWORD')
-                        }
-                    }
-                }
-            }
-
-            if (hasProperty('PROGUARD_SIGNING_KEY')) {
-                // We use in-memory ascii-armored keys
-                // See https://docs.gradle.org/current/userguide/signing_plugin.html#sec:in-memory-keys
-                signing {
-                    String key = findProperty('PROGUARD_SIGNING_KEY')
-                    String password = findProperty('PROGUARD_SIGNING_PASSWORD')
-                    useInMemoryPgpKeys(key, password)
-                    sign publishing.publications.getByName(project.name)
                 }
             }
         }
     }
 }
 
+// Add publication
 allprojects { Project project ->
     afterEvaluate {
-        if (pluginManager.hasPlugin('java') && pluginManager.hasPlugin('maven-publish')) {
+        if (pluginManager.hasPlugin('maven-publish')) {
+            configure(project) {
+                publishing {
+                    publications {
+                        create(project.name, MavenPublication) {
+                            pom {
+                                artifactId = "proguard-$project.name"
+                                name = "$group:$artifactId"
+                                url = 'https://www.guardsquare.com/proguard'
+                                licenses {
+                                    license {
+                                        name = 'GNU General Public License, Version 2'
+                                        url = 'https://www.gnu.org/licenses/gpl-2.0.txt'
+                                        distribution = 'repo'
+                                    }
+                                }
+                                issueManagement {
+                                    system = 'Github Tracker'
+                                    url = 'https://github.com/Guardsquare/proguard/issues'
+                                }
+                                scm {
+                                    url = 'https://github.com/Guardsquare/proguard.git'
+                                    connection = 'scm:git:https://github.com/Guardsquare/proguard.git'
+                                }
+                                developers {
+                                    developer {
+                                        id = 'lafortune'
+                                        name = 'Eric Lafortune'
+                                        organization = 'Guardsquare'
+                                        organizationUrl = 'https://www.guardsquare.com/'
+                                        roles = ['Project Administrator', 'Developer']
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+// Configure default publication (all Java projects)
+allprojects { Project project ->
+    afterEvaluate {
+        if  (pluginManager.hasPlugin('maven-publish') && pluginManager.hasPlugin('java')) {
             configure(project) {
                 javadoc {
                     options.addStringOption('Xdoclint:none', '-quiet')
@@ -102,10 +118,6 @@ allprojects { Project project ->
                     publications {
                         getByName(project.name) {
                             from components.java
-                            // Do not change artifact ID if already overriden at project level.
-                            if (artifactId == project.name) {
-                                artifactId = "proguard-$project.name"
-                            }
                         }
                     }
                 }
@@ -114,9 +126,10 @@ allprojects { Project project ->
     }
 }
 
+// Configure bintray
 allprojects { Project project ->
     afterEvaluate {
-        if (pluginManager.hasPlugin('com.jfrog.bintray') && pluginManager.hasPlugin('maven-publish')) {
+        if (pluginManager.hasPlugin('maven-publish') && pluginManager.hasPlugin('com.jfrog.bintray')) {
             configure(project) {
                 bintray {
                     Publication pub = publishing.publications.getByName(project.name)

--- a/gradle-plugin/build.gradle
+++ b/gradle-plugin/build.gradle
@@ -75,10 +75,16 @@ dependencies {
     testImplementation "commons-io:commons-io:2.8.0"
 }
 
-publishing {
-    publications {
-        getByName('gradle-plugin') {
-            artifactId = 'proguard-gradle'
-        }
+afterEvaluate {
+    /*  This project gets two publications:
+        - "pluginMaven" is the default from `java-gradle-plugin`
+          and must not be automatically published.
+        - "<project.name>" is created by ProGuard custom logic
+          and should have its artifact ID adjusted.
+     */
+    tasks.withType(AbstractPublishToMaven).matching { task ->
+        task.publication.name == 'pluginMaven'
+    } each {task ->
+        task.enabled = false
     }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -24,3 +24,5 @@ include 'gui'
 include 'gradle-plugin'
 include 'ant'
 include 'annotations'
+
+project(':gradle-plugin').name = 'gradle'


### PR DESCRIPTION
Plugin project recently started using the `java-gradle-plugin` plugin which added an extra unwanted `pluginMaven` publication. This request disables Maven publishing tasks for that publication and also fixes the POM name.