### PR TITLE
Remove static cache for generated names in SimpleNameFactory

### DIFF
--- a/base/src/proguard/obfuscate/SimpleNameFactory.java
+++ b/base/src/proguard/obfuscate/SimpleNameFactory.java
@@ -20,9 +20,6 @@
  */
 package proguard.obfuscate;
 
-import java.util.*;
-
-
 /**
  * This <code>NameFactory</code> generates unique short names, using mixed-case
  * characters or lower-case characters only.
@@ -33,12 +30,8 @@ public class SimpleNameFactory implements NameFactory
 {
     private static final int CHARACTER_COUNT = 26;
 
-    private static final List cachedMixedCaseNames = new ArrayList();
-    private static final List cachedLowerCaseNames = new ArrayList();
-
     private final boolean generateMixedCaseNames;
     private int     index = 0;
-
 
     /**
      * Creates a new <code>SimpleNameFactory</code> that generates mixed-case names.
@@ -79,22 +72,8 @@ public class SimpleNameFactory implements NameFactory
      */
     private String name(int index)
     {
-        // Which cache do we need?
-        List cachedNames = generateMixedCaseNames ?
-            cachedMixedCaseNames :
-            cachedLowerCaseNames;
-
-        // Do we have the name in the cache?
-        if (index < cachedNames.size())
-        {
-            return (String)cachedNames.get(index);
-        }
-
-        // Create a new name and cache it.
-        String name = newName(index);
-        cachedNames.add(index, name);
-
-        return name;
+        // Create a new name for this index
+        return newName(index);
     }
 
 

--- a/base/src/proguard/obfuscate/SimpleNameFactory.java
+++ b/base/src/proguard/obfuscate/SimpleNameFactory.java
@@ -2,7 +2,7 @@
  * ProGuard -- shrinking, optimization, obfuscation, and preverification
  *             of Java bytecode.
  *
- * Copyright (c) 2002-2020 Guardsquare NV
+ * Copyright (c) 2002-2021 Guardsquare NV
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the Free


### PR DESCRIPTION
The `SimpleNameFactory` was using a static List in an attempt to improve performance,
by avoiding the need to recreate the String name multiple times. The implementation
was not thread-safe, and could result in invalid names being produced when Proguard
was being run concurrently within the same classloader.

When 2 threads entered `getName()` simultaneously, they could both construct the same
name value for the same index, and both would then add these names to the static Map.
This resulted in a name List like `['a', 'a', 'c', ...].

This bug would manifest itself with a `Duplicate Jar Entry` exception, due to the fact
that `SimpleNameFactory` would return the same name value on subsequent calls.
This fact was verified by logging the names produced by `SimpleNameFactory`.

This commit merely removes the questionable optimization. If name generation is demonstrated 
to be a performance bottleneck a safer optimization should be implemented, ensuring
correct synchronization on shared resources.