### PR TITLE
Fix publication signing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,16 +43,6 @@ allprojects { Project project ->
                         }
                     }
                 }
-                if (hasProperty('PROGUARD_SIGNING_KEY')) {
-                    // We use in-memory ascii-armored keys
-                    // See https://docs.gradle.org/current/userguide/signing_plugin.html#sec:in-memory-keys
-                    signing {
-                        String key = findProperty('PROGUARD_SIGNING_KEY')
-                        String password = findProperty('PROGUARD_SIGNING_PASSWORD')
-                        useInMemoryPgpKeys(key, password)
-                        sign publishing.publications.getByName(project.name)
-                    }
-                }
             }
         }
     }
@@ -120,6 +110,26 @@ allprojects { Project project ->
                         getByName(project.name) {
                             from components.java
                         }
+                    }
+                }
+            }
+        }
+    }
+}
+
+// Configure signing
+allprojects { Project project ->
+    afterEvaluate {
+        if (pluginManager.hasPlugin('maven-publish')) {
+            configure(project) {
+                if (project.hasProperty('PROGUARD_SIGNING_KEY')) {
+                    // We use in-memory ascii-armored keys
+                    // See https://docs.gradle.org/current/userguide/signing_plugin.html#sec:in-memory-keys
+                    signing {
+                        String key = project.findProperty('PROGUARD_SIGNING_KEY')
+                        String password = project.findProperty('PROGUARD_SIGNING_PASSWORD')
+                        useInMemoryPgpKeys(key, password)
+                        sign publishing.publications.getByName(project.name)
                     }
                 }
             }


### PR DESCRIPTION
Publication signing is broken.

We must check for key existence on the `project` variable and move signing code after the publication block.