### PR TITLE
Make ProGuardTask output properties public

### DIFF
--- a/gradle-plugin/src/proguard/gradle/ProGuardTask.java
+++ b/gradle-plugin/src/proguard/gradle/ProGuardTask.java
@@ -70,26 +70,26 @@ public abstract class ProGuardTask extends DefaultTask
     // but package visible or protected methods are ok.
 
     @Classpath
-    protected FileCollection getInJarFileCollection()
+    public FileCollection getInJarFileCollection()
     {
         return getProject().files(inJarFiles);
     }
 
     @OutputFiles
-    protected FileCollection getOutJarFileCollection()
+    public FileCollection getOutJarFileCollection()
     {
         return getProject().files(outJarFiles);
     }
 
     @Classpath
-    protected FileCollection getLibraryJarFileCollection()
+    public FileCollection getLibraryJarFileCollection()
     {
         return getProject().files(libraryJarFiles);
     }
 
     @InputFiles
     @PathSensitive(PathSensitivity.RELATIVE)
-    protected FileCollection getConfigurationFileCollection()
+    public FileCollection getConfigurationFileCollection()
     {
         return getProject().files(configurationFiles);
     }


### PR DESCRIPTION
Otherwise it's not possible to consume outputs in some other task
without using reflection.

With this change users can now wire up `ProGuardTask` with other tasks like this:

```kotlin
// build.gradle.kts
tasks {
  val proguard by registering(ProGuardTask::class)

  register<Copy>("copyOutJars") {
    from(proguard.map { it.outJarFileCollection })
    into("$buildDir/outJars")
  }
}
```

Gradle will then automatically track the task dependency between proguard and the consuming task.