### PR TITLE
Change ProGuardCORE dependency version to 7.1.0-beta4

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 proguardVersion = 7.1.0-beta5
-proguardCoreVersion = 7.1.0-beta5
+proguardCoreVersion = 7.1.0-beta4
 gsonVersion = 2.8.5
 kotlinVersion = 1.3.72
 kotlinxMetadataVersion = 0.1.0


### PR DESCRIPTION
7.1.0-beta4 is the latest published version.