### PR TITLE
Whitelist `jdk.internal.reflect` package in GPL warning

### DIFF
--- a/base/src/proguard/GPL.java
+++ b/base/src/proguard/GPL.java
@@ -160,6 +160,7 @@ public class GPL
     private static boolean isKnown(String packageName)
     {
         return packageName.startsWith("java")                   ||
+               packageName.startsWith("jdk.internal.reflect")   ||
                packageName.startsWith("sun.reflect")            ||
                packageName.startsWith("proguard")               ||
                packageName.startsWith("org.apache.tools.ant")   ||


### PR DESCRIPTION
JDK8 classes in `sun.reflect` have been relocated to `jdk.internal.reflect` in JDK9+.
This change ensures that a GPL warning is not printed when `jdk.internal.reflect`
is detected in linked packages.