### PR TITLE
Make NameMarker public

### DIFF
--- a/base/src/proguard/obfuscate/NameMarker.java
+++ b/base/src/proguard/obfuscate/NameMarker.java
@@ -39,7 +39,7 @@ import proguard.classfile.visitor.*;
  *
  * @author Eric Lafortune
  */
-class      NameMarker
+public class      NameMarker
 implements ClassVisitor,
            MemberVisitor,
            AttributeVisitor,


### PR DESCRIPTION
This is helpful since it's referenced from Obfuscator