### PR TITLE
Remove `extendsAnnotationType` from `ClassSpecificationVisitorFactory` optimization

### DIFF
--- a/base/src/main/java/proguard/ClassSpecificationVisitorFactory.java
+++ b/base/src/main/java/proguard/ClassSpecificationVisitorFactory.java
@@ -240,10 +240,6 @@ public class ClassSpecificationVisitorFactory
                 className != null ?
                     new NamedClassVisitor(combinedClassVisitor, className) :
 
-                // If an extendsAnnotationType is specified, start visiting from matching extendsAnnotationType classes.
-                extendsAnnotationType != null ?
-                    new FilteredClassVisitor(extendsAnnotationTypeMatcher, combinedClassVisitor) :
-
                 // If an extendsClassName is specified, start visiting from matching extendsClassName classes.
                 extendsClassName != null ?
                     new FilteredClassVisitor(extendsClassNameMatcher, combinedClassVisitor) :

--- a/base/src/test/kotlin/proguard/ClassSpecificationVisitorFactoryTest.kt
+++ b/base/src/test/kotlin/proguard/ClassSpecificationVisitorFactoryTest.kt
@@ -87,4 +87,23 @@ class ClassSpecificationVisitorFactoryTest : FreeSpec({
             }
         }
     }
+
+    "Given a class specification extending an annotation class" - {
+        val (programClassPool, _) = ClassPoolBuilder.fromSource(
+            JavaSource("Annotation.java", "@interface Annotation { }"),
+            JavaSource("FooBar.java", "class FooBar extends Bar { }"),
+            JavaSource("Bar.java", "@Annotation class Bar { }")
+        )
+        val spec = "-keep class * extends @Annotation *".asConfiguration().keep.first()
+        val classVisitor = spyk<ClassVisitor>()
+        val visitor = KeepClassSpecificationVisitorFactory(true, false, false).createClassPoolVisitor(
+            spec, classVisitor, null, null, null
+        )
+        "Then the visitor should visit the matched class" {
+            programClassPool.accept(visitor)
+            verify(exactly = 1) {
+                classVisitor.visitAnyClass(programClassPool.getClass("FooBar"))
+            }
+        }
+    }
 })

--- a/docs/md/manual/releasenotes.md
+++ b/docs/md/manual/releasenotes.md
@@ -3,6 +3,7 @@
 ### Bug fixes
 
 - Fix "Can't save configuration file" error in ProGuardGUI. (`PGD-220`)
+- Fix rule configurations that extend annotation classes. (`PGD-229`)
 
 ## Version 7.2.1
 


### PR DESCRIPTION
An optimisation was introduced in commit
ee0630eeedc55e9103709329a3f9396cb099d680 attempting to reduce the number
of classes visited by a visitor created by the
`ClassSpecificationVisitorFactory`.

The fix introduced a bug because the `extendsAnnotationTypeMatcher`
matches types like `LMyAnnotation;` rather than class names.

Closes: #229
