### PR TITLE
Fix "No matching variant" issue when using Gradle 7.4 and Java 8

### DIFF
--- a/annotations/build.gradle
+++ b/annotations/build.gradle
@@ -3,9 +3,6 @@ plugins {
     id 'maven-publish'
 }
 
-sourceCompatibility = "${target}"
-targetCompatibility = "${target}"
-
 sourceSets.main {
     java {
         srcDirs = ['src']

--- a/ant/build.gradle
+++ b/ant/build.gradle
@@ -10,9 +10,6 @@ repositories {
     mavenCentral()
 }
 
-sourceCompatibility = "${target}"
-targetCompatibility = "${target}"
-
 sourceSets.main {
     java {
         srcDirs = ['src']

--- a/base/build.gradle
+++ b/base/build.gradle
@@ -13,11 +13,6 @@ repositories {
     maven { url 'https://jitpack.io' }
 }
 
-java {
-    sourceCompatibility = JavaVersion.toVersion("${target}")
-    targetCompatibility = JavaVersion.toVersion("${target}")
-}
-
 tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile) {
   kotlinOptions {
     jvmTarget = "${target}"

--- a/build.gradle
+++ b/build.gradle
@@ -105,6 +105,9 @@ allprojects { Project project ->
                     options.addStringOption('Xdoclint:none', '-quiet')
                 }
                 java {
+                    toolchain {
+                        languageVersion.set(JavaLanguageVersion.of(8))
+                    }
                     withJavadocJar()
                     withSourcesJar()
                 }

--- a/docs/md/manual/releasenotes.md
+++ b/docs/md/manual/releasenotes.md
@@ -3,6 +3,7 @@
 ### Bug fixes
 
 - Fix "Can't save configuration file" error in ProGuardGUI. (`PGD-220`)
+- Fix "No matching variant" Gradle plugin error when using Gradle 7.4 and Java 8. (`PGD-2311)
 
 ## Version 7.2.1
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.1.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gui/build.gradle
+++ b/gui/build.gradle
@@ -10,9 +10,6 @@ repositories {
     mavenCentral()
 }
 
-sourceCompatibility = "${target}"
-targetCompatibility = "${target}"
-
 sourceSets.main {
     java {
         srcDirs = ['src']

--- a/proguard-app/build.gradle
+++ b/proguard-app/build.gradle
@@ -10,9 +10,6 @@ repositories {
     mavenCentral()
 }
 
-sourceCompatibility = "${target}"
-targetCompatibility = "${target}"
-
 dependencies {
    implementation project(':base')
 }

--- a/retrace/build.gradle
+++ b/retrace/build.gradle
@@ -10,9 +10,6 @@ repositories {
     mavenCentral()
 }
 
-sourceCompatibility = "${target}"
-targetCompatibility = "${target}"
-
 sourceSets.main {
     java {
         srcDirs = ['src']


### PR DESCRIPTION
[Update Gradle version to 7.4 Set Java 8 version in main build.gradle for all projects Closes: #231](https://github.com/Guardsquare/proguard/pull/235)