### PR TITLE
Improve UX for -target deprecation

### DIFF
--- a/base/src/main/java/proguard/AfterInitConfigurationChecker.java
+++ b/base/src/main/java/proguard/AfterInitConfigurationChecker.java
@@ -53,7 +53,7 @@ public class AfterInitConfigurationChecker implements Pass
         @Override
         public void visitProgramClass(ProgramClass programClass)
         {
-            if (programClass.u4version > maxClassFileVersion)
+            if (programClass.u4version > maxClassFileVersion && programClass.u4version != target)
             {
                 throw new RuntimeException("-target can only be used with class file versions <= " + ClassUtil.internalMajorClassVersion(maxClassFileVersion) +
                                            " (Java " + ClassUtil.externalClassVersion(maxClassFileVersion) + ")." + System.lineSeparator() +

--- a/base/src/main/java/proguard/AfterInitConfigurationChecker.java
+++ b/base/src/main/java/proguard/AfterInitConfigurationChecker.java
@@ -7,6 +7,8 @@
 
 package proguard;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import proguard.classfile.*;
 import proguard.classfile.util.ClassUtil;
 import proguard.classfile.visitor.ClassVisitor;
@@ -19,6 +21,8 @@ import proguard.pass.Pass;
 public class AfterInitConfigurationChecker implements Pass
 {
     private final Configuration configuration;
+
+    private static final Logger logger = LogManager.getLogger(AfterInitConfigurationChecker.class);
 
     public AfterInitConfigurationChecker(Configuration configuration)
     {
@@ -53,12 +57,20 @@ public class AfterInitConfigurationChecker implements Pass
         @Override
         public void visitProgramClass(ProgramClass programClass)
         {
-            if (programClass.u4version > maxClassFileVersion && programClass.u4version != target)
+            if (programClass.u4version > maxClassFileVersion)
             {
-                throw new RuntimeException("-target can only be used with class file versions <= " + ClassUtil.internalMajorClassVersion(maxClassFileVersion) +
-                                           " (Java " + ClassUtil.externalClassVersion(maxClassFileVersion) + ")." + System.lineSeparator() +
-                                           "The input classes contain version " + ClassUtil.internalMajorClassVersion(programClass.u4version)   +
-                                           " class files which cannot be backported to target version (" + ClassUtil.internalMajorClassVersion(target) + ").");
+                if (programClass.u4version != target)
+                {
+                    throw new RuntimeException("-target can only be used with class file versions <= " + ClassUtil.internalMajorClassVersion(maxClassFileVersion) +
+                            " (Java " + ClassUtil.externalClassVersion(maxClassFileVersion) + ")." + System.lineSeparator() +
+                            "The input classes contain version " + ClassUtil.internalMajorClassVersion(programClass.u4version)   +
+                            " class files which cannot be backported to target version (" + ClassUtil.internalMajorClassVersion(target) + ").");
+                }
+
+                logger.warn(
+                        "-target is deprecated when using class file above "+ ClassUtil.internalMajorClassVersion(maxClassFileVersion) +
+                        " (Java " + ClassUtil.externalClassVersion(maxClassFileVersion) + ")."
+                );
             }
         }
 

--- a/base/src/test/kotlin/proguard/AfterInitConfigurationCheckerTest.kt
+++ b/base/src/test/kotlin/proguard/AfterInitConfigurationCheckerTest.kt
@@ -18,6 +18,7 @@ import proguard.classfile.VersionConstants.CLASS_VERSION_17
 import proguard.classfile.VersionConstants.CLASS_VERSION_18
 import proguard.classfile.VersionConstants.CLASS_VERSION_1_6
 import testutils.asConfiguration
+import testutils.getLogOutputOf
 import java.util.UUID
 
 /**
@@ -83,6 +84,19 @@ class AfterInitConfigurationCheckerTest : FreeSpec({
             }
 
             shouldNotThrow<RuntimeException> { AfterInitConfigurationChecker(configuration).execute(view) }
+        }
+
+        "It should print a warning" {
+            val view = AppView()
+            with(view.programClassPool) {
+                addClass(FakeClass(CLASS_VERSION_17))
+                addClass(FakeClass(CLASS_VERSION_17))
+            }
+
+            val output = getLogOutputOf {
+                AfterInitConfigurationChecker(configuration).execute(view)
+            }
+            output shouldContain "-target is deprecated when using class file above"
         }
 
         "It should throw an exception if -target is set and the version of one of the classes version is different from the target version" {

--- a/base/src/test/kotlin/proguard/AfterInitConfigurationCheckerTest.kt
+++ b/base/src/test/kotlin/proguard/AfterInitConfigurationCheckerTest.kt
@@ -14,8 +14,11 @@ import io.kotest.matchers.string.shouldContain
 import proguard.classfile.ProgramClass
 import proguard.classfile.VersionConstants.CLASS_VERSION_11
 import proguard.classfile.VersionConstants.CLASS_VERSION_12
+import proguard.classfile.VersionConstants.CLASS_VERSION_17
+import proguard.classfile.VersionConstants.CLASS_VERSION_18
 import proguard.classfile.VersionConstants.CLASS_VERSION_1_6
 import testutils.asConfiguration
+import java.util.UUID
 
 /**
  * Test the after init checks.
@@ -25,7 +28,7 @@ class AfterInitConfigurationCheckerTest : FreeSpec({
     // Mock a program class with the given class file version.
     class FakeClass(version: Int) : ProgramClass(version, 1, emptyArray(), 1, -1, -1) {
         override fun getClassName(constantIndex: Int): String {
-            return "Fake"
+            return "Fake${UUID.randomUUID()}"
         }
     }
 
@@ -63,6 +66,38 @@ class AfterInitConfigurationCheckerTest : FreeSpec({
             shouldNotThrow<RuntimeException> {
                 AfterInitConfigurationChecker(configuration).execute(view)
             }
+        }
+    }
+
+    "Given a configuration with a target specified and classes above Java 11" - {
+
+        val configuration = """
+            -target 17
+        """.trimIndent().asConfiguration()
+
+        "It should not throw an exception if -target is set but all the classes are already at the targeted version (no backport needed)" {
+            val view = AppView()
+            with(view.programClassPool) {
+                addClass(FakeClass(CLASS_VERSION_17))
+                addClass(FakeClass(CLASS_VERSION_17))
+            }
+
+            shouldNotThrow<RuntimeException> { AfterInitConfigurationChecker(configuration).execute(view) }
+        }
+
+        "It should throw an exception if -target is set and the version of one of the classes version is different from the target version" {
+            val view = AppView()
+            with(view.programClassPool) {
+                addClass(FakeClass(CLASS_VERSION_18))
+                addClass(FakeClass(CLASS_VERSION_17))
+            }
+
+            val exception = shouldThrow<RuntimeException> {
+                AfterInitConfigurationChecker(configuration).execute(view)
+            }
+
+            exception.message shouldContain "-target can only be used with class file versions <= 55 (Java 11)."
+            exception.message shouldContain "The input classes contain version 62 class files which cannot be backported to target version (61)."
         }
     }
 

--- a/base/src/test/kotlin/testutils/LogUtils.kt
+++ b/base/src/test/kotlin/testutils/LogUtils.kt
@@ -1,0 +1,25 @@
+package testutils
+
+import org.apache.logging.log4j.core.LoggerContext
+import org.apache.logging.log4j.core.appender.OutputStreamAppender
+import java.io.ByteArrayOutputStream
+import java.util.*
+
+
+fun getLogOutputOf(closure: () -> Unit): String {
+    val loggerOutput = ByteArrayOutputStream()
+    val context = LoggerContext.getContext(false)
+    val config = context.configuration
+    val layout = config.rootLogger.appenders.values.first().layout
+    val name = "Logger-${UUID.randomUUID()}"
+    val appender = OutputStreamAppender.createAppender(layout, null, loggerOutput, name, false, true)
+    appender.start()
+    config.addAppender(appender)
+    config.rootLogger.addAppender(appender, null, null)
+    try {
+        closure()
+    } finally {
+        config.rootLogger.removeAppender(name)
+    }
+    return loggerOutput.toString()
+}


### PR DESCRIPTION
Don't trigger the -target seatbelt when all classes are already at target version (no backport needed).