### PR TITLE
Update to Gradle 7.5

### DIFF
--- a/base/build.gradle
+++ b/base/build.gradle
@@ -50,9 +50,8 @@ jar {
 
 // Early access automatic downloads are not yet supported:
 // https://github.com/gradle/gradle/issues/14814
-// But it will work if e.g. Java 17-ea is pre-installed
-// TODO: Skip Java 9 until updating Gradle to 7.5 https://github.com/gradle/gradle/issues/20369
-def javaVersionsForTest = 10..17
+// But it will work if e.g. Java N-ea is pre-installed
+def javaVersionsForTest = 9..18
 
 test {
     useJUnitPlatform()

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Allows enabling Java 9 testing again and additionally adding Java 18 testing.
