### PR TITLE
issue 277

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -8,10 +8,7 @@ on:
       - master
 jobs:
   build:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, windows-latest]
+    runs-on: windows-latest
     steps:
       - uses: actions/checkout@v2
         with:
@@ -24,3 +21,8 @@ jobs:
           build-root-directory: proguard-main/
           wrapper-directory: proguard-main/
           arguments: :gradle:test
+      - name: Publish Unit Test Results
+        uses: EnricoMi/publish-unit-test-result-action@v1.19
+        if: always()
+        with:
+          files: gradle-plugin/build/test-results/**/*.xml

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -21,3 +21,8 @@ jobs:
           build-root-directory: proguard-main/
           wrapper-directory: proguard-main/
           arguments: :gradle:test --info
+      - name: Publish Test Report
+        uses: mikepenz/action-junit-report@v3
+        if: always() # always run even if the previous step fails
+        with:
+          report_paths: '**/build/test-results/test/TEST-*.xml'

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -8,7 +8,10 @@ on:
       - master
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
     steps:
       - uses: actions/checkout@v2
         with:
@@ -20,4 +23,4 @@ jobs:
         with:
           build-root-directory: proguard-main/
           wrapper-directory: proguard-main/
-          arguments: test :base:testAllJavaVersions :base:jacocoTestReport jar
+          arguments: :gradle:test

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -20,9 +20,4 @@ jobs:
         with:
           build-root-directory: proguard-main/
           wrapper-directory: proguard-main/
-          arguments: :gradle:test
-      - name: Publish Unit Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v1.19
-        if: always()
-        with:
-          files: gradle-plugin/build/test-results/**/*.xml
+          arguments: :gradle:test --info

--- a/gradle-plugin/src/main/kotlin/proguard/gradle/plugin/android/AndroidPlugin.kt
+++ b/gradle-plugin/src/main/kotlin/proguard/gradle/plugin/android/AndroidPlugin.kt
@@ -110,7 +110,7 @@ class AndroidPlugin(private val androidExtension: BaseExtension) : Plugin<Projec
         if (!androidExtension.aaptAdditionalParameters.contains("--proguard")) {
             androidExtension.aaptAdditionalParameters.addAll(listOf(
                     "--proguard",
-                    "${project.buildDir.absolutePath}/intermediates/proguard/configs/aapt_rules.pro"))
+                    File(project.buildDir, "intermediates/proguard/configs/aapt_rules.pro").absolutePath))
         }
 
         if (!androidExtension.aaptAdditionalParameters.contains("--proguard-conditional-keep-rules")) {


### PR DESCRIPTION
- Fix proguard rules path for Windows
- Temporarily run only Gradle tests
