### PR TITLE
Replace ProGuard Assembler dependency

### DIFF
--- a/base/build.gradle
+++ b/base/build.gradle
@@ -11,7 +11,6 @@ plugins {
 
 repositories {
     mavenCentral()
-    maven { url 'https://jitpack.io' }
 }
 
 tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile) {
@@ -35,12 +34,7 @@ dependencies {
     testImplementation 'io.kotest:kotest-property-jvm:5.3.1' // for kotest property test
     testImplementation "io.mockk:mockk:1.12.3" // for mocking
 
-    // For assembling ProGuard assembler snippets
-    testImplementation ('com.github.Guardsquare:proguard-assembler:master-SNAPSHOT') {
-        exclude group: 'com.guardsquare', module: 'proguard-core'
-    }
-
-    testImplementation(testFixtures("com.guardsquare:proguard-core")) {
+    testImplementation(testFixtures("com.guardsquare:proguard-core:9.0.5")) {
         exclude group: 'com.guardsquare', module: 'proguard-core'
     }
 }


### PR DESCRIPTION
It's now published to Maven Central. It's not needed directly but for the test fixtures which now has a transitive dependency on the Maven Central artefact.
