### PR TITLE
Support `.proguard` file extension in addition to `.pro`

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ bin\proguard.bat <options...>
 ```
 
 Typically, you'll put most options in a configuration file (say,
-`myconfig.pro`), and just call
+`myconfig.pro` or `myconfig.proguard`), and just call
 
 ```bash
 bin/proguard.sh @myconfig.pro

--- a/README.md
+++ b/README.md
@@ -79,8 +79,8 @@ bin/proguard.sh <options...>
 
 or on Windows:
 
-```
-bin\proguard.bat <options...>
+```batch
+bin\proguard <options...>
 ```
 
 Typically, you'll put most options in a configuration file (say,
@@ -89,10 +89,11 @@ Typically, you'll put most options in a configuration file (say,
 ```bash
 bin/proguard.sh @myconfig.pro
 ```
+
 or on Windows:
 
-```
-bin\proguard.bat @myconfig.pro
+```batch
+bin\proguard @myconfig.pro
 ```
 
 All available options are described in the [configuration section of the manual](https://www.guardsquare.com/manual/configuration/usage).

--- a/annotations/build.gradle
+++ b/annotations/build.gradle
@@ -13,6 +13,7 @@ sourceSets.main {
         include '**/*.gif'
         include '**/*.png'
         include '**/*.pro'
+        include '**/*.proguard'
     }
 }
 

--- a/ant/build.gradle
+++ b/ant/build.gradle
@@ -21,6 +21,7 @@ sourceSets.main {
         include '**/*.gif'
         include '**/*.png'
         include '**/*.pro'
+        include '**/*.proguard'
     }
 }
 

--- a/docs/md/manual/building.md
+++ b/docs/md/manual/building.md
@@ -17,7 +17,7 @@ You can then execute a composite build with the following Gradle command:
     ```
 
 === "Windows"
-    ```bash
+    ```batch
     gradlew assemble
     ```
 
@@ -33,8 +33,8 @@ scripts in `bin`, for example:
 
 === "Windows"
 
-    ```bash
-    bin\proguard.bat
+    ```batch
+    bin\proguard
     ```
 
 ## Publish to Maven local
@@ -48,7 +48,7 @@ You can publish the artifacts to your local Maven cache (something like `~/.m2/`
     ```
 
 === "Windows"
-    ```bash
+    ```batch
     gradlew publishToMavenLocal
     ```
 
@@ -65,7 +65,7 @@ You can build tar and zip archives with the binaries and documentation:
 
 === "Windows"
 
-    ```bash
+    ```batch
     gradlew distTar distZip
     ```
 

--- a/docs/md/manual/quickstart.md
+++ b/docs/md/manual/quickstart.md
@@ -24,10 +24,10 @@ ProGuard can then be executed directly from the command line by calling a script
     ```
 
 === "Windows"
-    ```bat
-    bin\proguard.bat -injars path/to/my-application.jar ^
-                     -outjars path/to/obfuscated-application.jar ^
-                     -libraryjars path/to/java/home/lib/rt.jar
+    ```batch
+    bin\proguard -injars path/to/my-application.jar ^
+                 -outjars path/to/obfuscated-application.jar ^
+                 -libraryjars path/to/java/home/lib/rt.jar
     ```
  
 For more detailed information see [standalone mode](setup/standalone.md).

--- a/docs/md/manual/refcard.md
+++ b/docs/md/manual/refcard.md
@@ -1,16 +1,16 @@
 ## Usage
 
 | OS         | Command
-|------------|-----------------------------
+|------------|------------------------------------------------------------------
 | Windows:   | `proguard` *options* ...
 | Linux/Mac: | `proguard.sh` *options* ...
 
 Typically:
 
 | OS         | Command
-|------------|-----------------------------
-| Windows:   | `proguard @myconfig.pro`
-| Linux/Mac: | `proguard.sh @myconfig.pro`
+|------------|------------------------------------------------------------------
+| Windows:   | `proguard @myconfig.pro`    <br> `proguard @myconfig.proguard`
+| Linux/Mac: | `proguard.sh @myconfig.pro` <br> `proguard.sh @myconfig.proguard`
 
 ## Options
 

--- a/docs/md/manual/setup/ant.md
+++ b/docs/md/manual/setup/ant.md
@@ -311,7 +311,7 @@ the following attributes (only for **`<proguard>`**) and nested elements:
   **`fileset`** element and supports all of its attributes and nested
   elements, including multiple files.
 
-## Class Path Attributes and Nested Elements {: #classpath}
+### Class Path Attributes and Nested Elements {: #classpath}
 
 The jar elements are **`path`** elements, so they can have any of the
 standard **`path`** attributes and nested elements. The most common
@@ -359,7 +359,7 @@ In addition, the jar elements can have ProGuard-style filter attributes:
 `zipfilter` = "[*file\_filter*](../configuration/usage.md#filefilters)"
 : An optional filter for all zip names that are encountered.
 
-## Keep Modifier Attributes {: #keepmodifier}
+### Keep Modifier Attributes {: #keepmodifier}
 
 The keep tags can have the following *modifier* attributes:
 
@@ -379,7 +379,7 @@ The keep tags can have the following *modifier* attributes:
 : Specifies whether the entry points specified in the keep tag may be
   obfuscated.
 
-## Class Specification Attributes and Nested Elements {: #classspecification}
+### Class Specification Attributes and Nested Elements {: #classspecification}
 
 The keep tags can have the following *class\_specification* attributes
 and *class\_member\_specifications* nested elements:
@@ -420,7 +420,7 @@ and *class\_member\_specifications* nested elements:
 `<constructor` [*class\_member\_specification*](#classmemberspecification) `/>`
 : Specifies a constructor.
 
-## Class Member Specification Attributes {: #classmemberspecification}
+### Class Member Specification Attributes {: #classmemberspecification}
 
 The class member tags can have the following
 *class\_member\_specification* attributes:

--- a/docs/md/manual/setup/gradleplugin.md
+++ b/docs/md/manual/setup/gradleplugin.md
@@ -124,7 +124,7 @@ You can then build your application as usual:
     ./gradlew assembleRelease
     ```
 === "Windows"
-    ```
+    ```batch
     gradlew assembleRelease
     ```
 
@@ -237,7 +237,7 @@ You can then build your application as usual:
     ./gradlew assembleRelease
     ```
 === "Windows"
-    ```
+    ```batch
     gradlew assembleRelease
     ```
 

--- a/docs/md/manual/setup/gradleplugin.md
+++ b/docs/md/manual/setup/gradleplugin.md
@@ -4,7 +4,7 @@ This page will guide you through to the basic steps of processing your Android a
 !!! tip "Java / Kotlin desktop or server projects"
     If you have a Java / Kotlin desktop or server project, you can find instructions [here](gradle.md).
 
-## ProGuard Gradle Plugin (AGP version 4.x - AGP 7.x)
+## ProGuard Gradle Plugin (AGP version 4.x - AGP 7.x) {: #proguard-gradle-plugin}
 
 You can add the ProGuard plugin to your project by
 including the following in your root level `build.gradle(.kts)` file:
@@ -179,7 +179,7 @@ version part.
 The example [`android-plugin`](https://github.com/Guardsquare/proguard/tree/master/examples/android-plugin)
 has a small working Android project using the ProGuard Gradle Plugin.
 
-## AGP Integrated ProGuard (AGP version <7)
+## AGP Integrated ProGuard (AGP version <7) {: #agp-integrated-proguard}
 
 ProGuard is integrated with older versions of the Android Gradle plugin. 
 If you have an Android Gradle project that uses such an AGP version, 

--- a/docs/md/manual/setup/standalone.md
+++ b/docs/md/manual/setup/standalone.md
@@ -6,12 +6,12 @@ To run ProGuard, just type:
     ```
 
 === "Windows"
-    ```
+    ```batch
     bin\proguard <options...>
     ```
 
 Typically, you'll put most options in a configuration file (say,
-`myconfig.pro`), and just call:
+`myconfig.pro` or `myconfig.proguard`), and just call:
 
 === "Linux/macOS"
     ```bash

--- a/docs/md/manual/setup/standalone.md
+++ b/docs/md/manual/setup/standalone.md
@@ -19,7 +19,7 @@ Typically, you'll put most options in a configuration file (say,
     ```
 
 === "Windows"
-    ```bash
+    ```batch
     bin\proguard @myconfig.pro
     ```
 
@@ -32,7 +32,7 @@ files. For instance:
     ```
 
 === "Windows"
-    ```
+    ```batch
     bin\proguard @myconfig.pro -verbose
     ```
 

--- a/gradle-plugin/src/main/kotlin/proguard/gradle/plugin/android/transforms/ArchiveConsumerRulesTransform.kt
+++ b/gradle-plugin/src/main/kotlin/proguard/gradle/plugin/android/transforms/ArchiveConsumerRulesTransform.kt
@@ -36,7 +36,7 @@ abstract class ArchiveConsumerRulesTransform : TransformAction<TransformParamete
                 FileSystems.getDefault().getPathMatcher("glob:proguard.txt"),
 
                 // Locations for consumer rules in jars.
-                FileSystems.getDefault().getPathMatcher("glob:META-INF/proguard/*.pro")
+                FileSystems.getDefault().getPathMatcher("glob:META-INF/proguard/*.{pro,proguard}")
         )
 
         ZipFile(inputFile).use { zip ->

--- a/gui/build.gradle
+++ b/gui/build.gradle
@@ -21,6 +21,7 @@ sourceSets.main {
         include '**/*.gif'
         include '**/*.png'
         include '**/*.pro'
+        include '**/*.proguard'
     }
 }
 

--- a/gui/src/proguard/gui/GUIResources.properties
+++ b/gui/src/proguard/gui/GUIResources.properties
@@ -597,7 +597,7 @@ cantSaveConfigurationFile  = Can''t save the configuration file [{0}]
 cantOpenStackTraceFile     = Can''t open the stack trace file [{0}]
 
 jarExtensions = *.jar, *.aar, *.war, *.ear, *.jmod, *.zip, *.apk, *.ap_ (archives and directories)
-proExtension  = *.pro (ProGuard configurations)
+proExtensions = *.pro, *.proguard (ProGuard configurations)
 
 addJars     = Add one or more jars or directories...
 chooseJars  = Choose different jars or directories...

--- a/gui/src/proguard/gui/ProGuardGUI.java
+++ b/gui/src/proguard/gui/ProGuardGUI.java
@@ -271,7 +271,7 @@ public class ProGuardGUI extends JFrame
         GridBagLayout layout = new GridBagLayout();
 
         configurationChooser.addChoosableFileFilter(
-            new ExtensionFileFilter(msg("proExtension"), new String[] { ".pro" }));
+            new ExtensionFileFilter(msg("proExtensions"), new String[] { ".pro", ".proguard" }));
 
         // Create the opening panel.
         Sprite splash =

--- a/retrace/build.gradle
+++ b/retrace/build.gradle
@@ -20,6 +20,7 @@ sourceSets.main {
         include '**/*.gif'
         include '**/*.png'
         include '**/*.pro'
+        include '**/*.proguard'
     }
 }
 


### PR DESCRIPTION
This PR makes ProGuard's GUI, as well as a piece of internal machinery in Gradle plugin, recognize ProGuard configuration files with a `.proguard` file extension in addition to `.pro`.

## Motivation

File extension names clash. In this case, ProGuard argfiles with source code in another programming language (which then clashed with yet another source code files...), leading to a messy project setup. I would like to maintain the advantage of automatic syntax coloring and configuration hints without sacrificing general usability (default `.txt` files offer no help at all), thus I propose a specialized (although kind of verbose) extension so that conflicts on that front can be avoided. This does not change already existing conventions in regards to e.g. loading AAPT rules or default transforms of jar artifacts.

## Addendum

While doing that I've noticed minor bugs in the documentation, so I proceeded to fix them in separate commits:
 - fixed and properly colorized Windows code blocks to use Batchfile syntax (mataha/proguard@c399d60)
 - fixed section titles in ant/gradle plugin setup for consistency with other ones in the manual (mataha/proguard@eff50c2)