### PR TITLE
Lambda inlining optimization

### DIFF
--- a/base/src/main/java/proguard/Configuration.java
+++ b/base/src/main/java/proguard/Configuration.java
@@ -200,6 +200,11 @@ public class Configuration
      */
     public boolean                      mergeInterfacesAggressively      = false;
 
+    /**
+     * Specifies whether lambdas should be inlined.
+     */
+    public boolean                      lambdaInlining                   = true;
+
     ///////////////////////////////////////////////////////////////////////////
     // Obfuscation options.
     ///////////////////////////////////////////////////////////////////////////

--- a/base/src/main/java/proguard/ProGuard.java
+++ b/base/src/main/java/proguard/ProGuard.java
@@ -38,6 +38,7 @@ import proguard.obfuscate.ResourceFileNameAdapter;
 import proguard.optimize.LineNumberTrimmer;
 import proguard.optimize.Optimizer;
 import proguard.optimize.gson.GsonOptimizer;
+import proguard.optimize.inline.LambdaInliner;
 import proguard.optimize.peephole.LineNumberLinearizer;
 import proguard.pass.PassRunner;
 import proguard.preverify.PreverificationClearer;
@@ -194,6 +195,11 @@ public class ProGuard
             StringMatcher filter = configuration.optimizations != null ?
                 new ListParser(new NameParser()).parse(configuration.optimizations) :
                 new ConstantMatcher(true);
+
+            if (configuration.lambdaInlining)
+            {
+                inlineLambdas();
+            }
 
             if (configuration.optimize &&
                 filter.matches(Optimizer.LIBRARY_GSON))
@@ -462,6 +468,11 @@ public class ProGuard
         passRunner.run(new GsonOptimizer(configuration), appView);
     }
 
+    private void inlineLambdas() throws Exception
+    {
+        LambdaInliner lambdaInliner = new LambdaInliner();
+        passRunner.run(lambdaInliner, appView);
+    }
 
     /**
      * Performs the optimization step.

--- a/base/src/main/java/proguard/optimize/inline/BaseLambdaInliner.java
+++ b/base/src/main/java/proguard/optimize/inline/BaseLambdaInliner.java
@@ -1,0 +1,301 @@
+package proguard.optimize.inline;
+
+import proguard.AppView;
+import proguard.classfile.*;
+import proguard.classfile.attribute.Attribute;
+import proguard.classfile.attribute.CodeAttribute;
+import proguard.classfile.attribute.visitor.AllAttributeVisitor;
+import proguard.classfile.attribute.visitor.AttributeVisitor;
+import proguard.classfile.constant.InterfaceMethodrefConstant;
+import proguard.classfile.constant.visitor.ConstantVisitor;
+import proguard.classfile.editor.ClassEditor;
+import proguard.classfile.editor.CodeAttributeEditor;
+import proguard.classfile.editor.ConstantPoolEditor;
+import proguard.classfile.editor.MethodCopier;
+import proguard.classfile.instruction.ConstantInstruction;
+import proguard.classfile.instruction.Instruction;
+import proguard.classfile.instruction.InstructionFactory;
+import proguard.classfile.instruction.VariableInstruction;
+import proguard.classfile.instruction.visitor.AllInstructionVisitor;
+import proguard.classfile.instruction.visitor.InstructionOpCodeFilter;
+import proguard.classfile.instruction.visitor.InstructionVisitor;
+import proguard.classfile.util.ClassReferenceInitializer;
+import proguard.classfile.util.ClassUtil;
+import proguard.classfile.util.InternalTypeEnumeration;
+import proguard.classfile.visitor.MemberVisitor;
+import proguard.evaluation.PartialEvaluator;
+import proguard.evaluation.TracedStack;
+import proguard.optimize.inline.lambda_locator.Lambda;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static java.lang.Math.max;
+
+public class BaseLambdaInliner implements MemberVisitor, InstructionVisitor, ConstantVisitor {
+    private final Clazz consumingClass;
+    private final Method consumingMethod;
+    private final AppView appView;
+    private final Lambda lambda;
+    private final CodeAttributeEditor codeAttributeEditor;
+    private final boolean isStatic;
+    private final int calledLambdaIndex;
+    private final int sizeAdjustedLamdaIndex;
+    private final PartialEvaluator partialEvaluator;
+    private Clazz interfaceClass;
+    private Clazz lambdaClass;
+    private Method lambdaInvokeMethod;
+    private String bridgeDescriptor;
+    private Method inlinedLambdaMethod;
+    private Method staticInvokeMethod;
+    private InterfaceMethodrefConstant referencedInterfaceConstant;
+    private final List<Integer> invokeMethodCallOffsets;
+
+    public BaseLambdaInliner(AppView appView, Clazz consumingClass, Method consumingMethod, Lambda lambda) {
+        this.consumingClass = consumingClass;
+        this.consumingMethod = consumingMethod;
+        this.appView = appView;
+        this.lambda = lambda;
+        this.codeAttributeEditor = new CodeAttributeEditor();
+        this.isStatic = (consumingMethod.getAccessFlags() & AccessConstants.STATIC) != 0;
+        this.calledLambdaIndex = Util.findFirstLambdaParameter(consumingMethod.getDescriptor(consumingClass), isStatic);
+        this.sizeAdjustedLamdaIndex = ClassUtil.internalMethodVariableIndex(consumingMethod.getDescriptor(consumingClass), true, calledLambdaIndex);
+        this.partialEvaluator = new PartialEvaluator();
+        this.invokeMethodCallOffsets = new ArrayList<>();
+    }
+
+    /**
+     * Idea: Inline a lambda by just giving it a consuming method and class in which it has to inline the particular
+     * lambda,  a reference to the newly created function with the inlined lambda is returned, the caller can then
+     * replace the call instruction with a call to this newly created function. This way we don't need to think about
+     * how it is called exactly, it can be used as a higher abstraction in other places.
+     */
+    public Method inline() {
+        if (consumingMethod instanceof LibraryMethod)
+            return null;
+
+        ConstantInstruction c = lambda.constantInstruction();
+        lambda.clazz().constantPoolEntryAccept(c.constantIndex, new LambdaImplementationVisitor((programClass, programMethod, interfaceClass, bridgeDescriptor) -> {
+            this.interfaceClass = interfaceClass;
+            this.lambdaClass = programClass;
+            this.lambdaInvokeMethod = programMethod;
+            this.bridgeDescriptor = bridgeDescriptor;
+
+            // First we copy the method from the anonymous lambda class into the class where it is used.
+            MethodCopier copier = new MethodCopier(programClass, programMethod, BaseLambdaInliner.this);
+            consumingClass.accept(copier);
+        }));
+
+        return inlinedLambdaMethod;
+    }
+
+    @Override
+    public void visitAnyMember(Clazz clazz, Member member) {
+        ProgramMethod method = (ProgramMethod) member;
+        method.u2accessFlags = (method.getAccessFlags() & ~AccessConstants.BRIDGE & ~AccessConstants.SYNTHETIC & ~AccessConstants.PRIVATE) | AccessConstants.STATIC;
+
+        // Copy the invoke method
+        String invokeMethodDescriptor = method.getDescriptor(consumingClass);
+        DescriptorModifier descriptorModifier = new DescriptorModifier(consumingClass);
+        staticInvokeMethod = descriptorModifier.modify(method,
+            desc -> {
+            // The method becomes static
+            String d = desc.replace("(", "(Ljava/lang/Object;");
+            // Change return type if it has an effect on the stack size
+            d = d.replace(")Ljava/lang/Double;", ")D");
+            d = d.replace(")Ljava/lang/Float;", ")F");
+            return d.replace(")Ljava/lang/Long;", ")J");
+            }
+        , true);
+
+        ProgramMethod copiedConsumingMethod = descriptorModifier.modify((ProgramMethod) consumingMethod, desc -> desc);
+
+        // Don't inline if the lamdba is passed to another method
+        try {
+            copiedConsumingMethod.accept(consumingClass, new RecursiveInliner(appView, consumingMethod, lambda));
+        } catch(CannotInlineException cie) {
+            ClassEditor classEditor = new ClassEditor((ProgramClass) consumingClass);
+            classEditor.removeMethod(copiedConsumingMethod);
+            classEditor.removeMethod(staticInvokeMethod);
+            return;
+        }
+
+        referencedInterfaceConstant = null;
+        invokeMethodCallOffsets.clear();
+
+        // Replace invokeinterface call to invoke method with invokestatic to staticInvokeMethod
+        codeAttributeEditor.reset(getMethodLength(copiedConsumingMethod, consumingClass));
+        copiedConsumingMethod.accept(consumingClass,
+                new AllAttributeVisitor(
+                new AllInstructionVisitor(
+                new InstructionOpCodeFilter(new int[] { Instruction.OP_INVOKEINTERFACE }, this))));
+
+        //  Remove return value's casting from staticInvokeMethod
+        staticInvokeMethod.accept(consumingClass, new AllAttributeVisitor(new AttributeVisitor() {
+            @Override
+            public void visitCodeAttribute(Clazz clazz, Method method, CodeAttribute codeAttribute) {
+                int len = codeAttribute.u4codeLength;
+                CodeAttributeEditor codeAttributeEditorStaticInvoke = new CodeAttributeEditor();
+                codeAttributeEditorStaticInvoke.reset(codeAttribute.u4codeLength);
+                codeAttribute.instructionsAccept(clazz, method, len - 4, len, new CastRemover(codeAttributeEditorStaticInvoke));
+                codeAttributeEditorStaticInvoke.visitCodeAttribute(clazz, method, codeAttribute);
+            }
+
+            @Override
+            public void visitAnyAttribute(Clazz clazz, Attribute attribute) {}
+        }));
+
+        if (referencedInterfaceConstant != null) {
+            InternalTypeEnumeration internalTypeEnumeration = new InternalTypeEnumeration(invokeMethodDescriptor);
+            int i = 0;
+            List<Integer> keepList = new ArrayList<>();
+            while(internalTypeEnumeration.hasMoreTypes()) {
+                if (internalTypeEnumeration.nextType().equals("Ljava/lang/Object;")) {
+                    // Argument i is object, we should keep the cast for this argument
+                    keepList.add(i);
+                }
+                i++;
+            }
+            int nbrArgs = ClassUtil.internalMethodParameterCount(invokeMethodDescriptor);
+
+            // Remove casting before and after invoke method call
+            // Uses same codeAttributeEditor as LambdaInvokeReplacer
+            copiedConsumingMethod.accept(consumingClass, new AllAttributeVisitor(new AttributeVisitor() {
+                @Override
+                public void visitCodeAttribute(Clazz clazz, Method method, CodeAttribute codeAttribute) {
+                    for (int invokeMethodCallOffset : invokeMethodCallOffsets) {
+                        int startOffset = max((invokeMethodCallOffset -(6 * nbrArgs)), 0);
+                        int endOffset = invokeMethodCallOffset + 8 + 1;
+                        if (InstructionFactory.create(codeAttribute.code, invokeMethodCallOffset + InstructionFactory.create(codeAttribute.code, invokeMethodCallOffset).length(invokeMethodCallOffset)).opcode == Instruction.OP_POP) {
+                            endOffset = invokeMethodCallOffset;
+                        }
+
+                        codeAttribute.instructionsAccept(consumingClass, method, startOffset, endOffset,
+                                new CastRemover(codeAttributeEditor, keepList)
+                        );
+                    }
+                    codeAttributeEditor.visitCodeAttribute(clazz, method, codeAttribute);
+                }
+
+                @Override
+                public void visitAnyAttribute(Clazz clazz, Attribute attribute) {}
+            }));
+        }
+
+        // Important for inlining, we need this so that method invocations have non-null referenced methods.
+        appView.programClassPool.classesAccept(
+                new ClassReferenceInitializer(appView.programClassPool, appView.libraryClassPool)
+        );
+
+        // Inlining phase 2, inline that static invoke method into the actual function that uses the lambda.
+        Util.inlineMethodInClass(consumingClass, staticInvokeMethod);
+
+        // Remove the static invoke method once it has been inlined
+        ClassEditor classEditor = new ClassEditor((ProgramClass) consumingClass);
+        classEditor.removeMethod(staticInvokeMethod);
+
+        // Remove checkNotNullParameter() call because arguments that are lambdas will be removed
+        copiedConsumingMethod.accept(consumingClass, new AllAttributeVisitor(new AllInstructionVisitor(new NullCheckRemover(sizeAdjustedLamdaIndex))));
+
+        //remove inlined lambda from arguments through the descriptor
+        Method methodWithoutLambdaParameter = descriptorModifier.modify(copiedConsumingMethod, desc -> {
+            List<String> list = new ArrayList<>();
+            InternalTypeEnumeration internalTypeEnumeration = new InternalTypeEnumeration(desc);
+            while(internalTypeEnumeration.hasMoreTypes()) {
+                list.add(internalTypeEnumeration.nextType());
+            }
+            list.remove(calledLambdaIndex - (isStatic ? 0 : 1));
+
+            return ClassUtil.internalMethodDescriptorFromInternalTypes(internalTypeEnumeration.returnType(), list);
+        }, true);
+
+
+        // Remove one of the arguments
+        methodWithoutLambdaParameter.accept(consumingClass, new LocalUsageRemover(codeAttributeEditor, sizeAdjustedLamdaIndex));
+
+        // The resulting new method is: methodWithoutLambdaParameter, the user of the BaseLambdaInliner can then replace
+        // calls to the old function to calls to this new function.
+        inlinedLambdaMethod = methodWithoutLambdaParameter;
+    }
+
+    @Override
+    public void visitConstantInstruction(Clazz consumingClass, Method consumingMethod, CodeAttribute consumingMethodCodeAttribute, int consumingMethodCallOffset, ConstantInstruction constantInstruction) {
+        consumingClass.constantPoolEntryAccept(constantInstruction.constantIndex, this);
+        Method invokeInterfaceMethod = referencedInterfaceConstant.referencedMethod;
+        Clazz invokeInterfaceClass = referencedInterfaceConstant.referencedClass;
+
+        // Check if this is an invokeinterface call to the lambda class invoke method
+        if (invokeInterfaceClass.getName().equals(interfaceClass.getName()) &&
+                invokeInterfaceMethod.getName(invokeInterfaceClass).equals(lambdaInvokeMethod.getName(lambdaClass)) &&
+                invokeInterfaceMethod.getDescriptor(invokeInterfaceClass).equals(bridgeDescriptor)
+        ) {
+            partialEvaluator.visitCodeAttribute(consumingClass, consumingMethod, consumingMethodCodeAttribute);
+            TracedStack tracedStack = partialEvaluator.getStackBefore(consumingMethodCallOffset);
+
+            // If we have a lambda with n arguments we have to skip those n arguments and then get the instance of the lambda used for calling invokeinterface.
+            int lambdaInstanceStackIndex = ClassUtil.internalMethodParameterCount(invokeInterfaceMethod.getDescriptor(invokeInterfaceClass));
+
+            consumingMethodCodeAttribute.instructionAccept(
+                consumingClass,
+                consumingMethod,
+                tracedStack.getTopActualProducerValue(lambdaInstanceStackIndex).instructionOffsetValue().instructionOffset(0),
+                new LambdaInvokeUsageReplacer(consumingMethodCallOffset)
+            );
+        }
+    }
+
+    @Override
+    public void visitInterfaceMethodrefConstant(Clazz clazz, InterfaceMethodrefConstant interfaceMethodrefConstant) {
+        referencedInterfaceConstant = interfaceMethodrefConstant;
+    }
+
+    private class LambdaInvokeUsageReplacer implements InstructionVisitor {
+        private final int possibleLambdaInvokeCallOffset;
+
+        public LambdaInvokeUsageReplacer(int possibleLambdaInvokeCallOffset) {
+            this.possibleLambdaInvokeCallOffset = possibleLambdaInvokeCallOffset;
+        }
+
+        @Override
+        public void visitVariableInstruction(Clazz clazz, Method method, CodeAttribute codeAttribute, int offset, VariableInstruction variableInstruction) {
+            // Uses same codeAttributeEditor as the casting remover
+            Instruction tracedInstruction = Util.traceParameter(partialEvaluator, codeAttribute, offset);
+            if (tracedInstruction.canonicalOpcode() == Instruction.OP_ALOAD) {
+                variableInstruction = (VariableInstruction) tracedInstruction;
+
+                // Check if the aload index is the same as the current lambda index in the arguments
+                if (variableInstruction.variableIndex == sizeAdjustedLamdaIndex) {
+                    // Replace call to lambda invoke method by a static call to the copied static invoke method
+                    ConstantPoolEditor constantPoolEditor = new ConstantPoolEditor((ProgramClass) clazz);
+                    int constantIndex = constantPoolEditor.addMethodrefConstant(clazz, staticInvokeMethod);
+
+                    codeAttributeEditor.replaceInstruction(possibleLambdaInvokeCallOffset, new ConstantInstruction(Instruction.OP_INVOKESTATIC, constantIndex));
+                    if (staticInvokeMethod.getDescriptor(consumingClass).endsWith("V")) {
+                        // Lambda that returns void, so we delete the pop instruction after the invoke because it originally returned the Object type
+                        codeAttributeEditor.deleteInstruction(possibleLambdaInvokeCallOffset + InstructionFactory.create(codeAttribute.code, possibleLambdaInvokeCallOffset).length(possibleLambdaInvokeCallOffset));
+                    }
+
+                    invokeMethodCallOffsets.add(possibleLambdaInvokeCallOffset);
+                }
+            }
+        }
+    }
+
+    /**
+     * @param method     A Method object from which we'll get the length.
+     * @param clazz      The class in which the method is.
+     * @return           The length of the method.
+     */
+    private int getMethodLength(Method method, Clazz clazz) {
+        final int[] length = new int[1];
+        method.accept(clazz, new AllAttributeVisitor(new AttributeVisitor() {
+            @Override
+            public void visitAnyAttribute(Clazz clazz, Attribute attribute) {}
+            @Override
+            public void visitCodeAttribute(Clazz clazz, Method method, CodeAttribute codeAttribute) {
+                length[0] = codeAttribute.u4codeLength;
+            }
+        }));
+        return length[0];
+    }
+}

--- a/base/src/main/java/proguard/optimize/inline/CallReplacer.java
+++ b/base/src/main/java/proguard/optimize/inline/CallReplacer.java
@@ -1,0 +1,48 @@
+package proguard.optimize.inline;
+
+import proguard.classfile.Clazz;
+import proguard.classfile.Method;
+import proguard.classfile.ProgramClass;
+import proguard.classfile.attribute.CodeAttribute;
+import proguard.classfile.constant.AnyMethodrefConstant;
+import proguard.classfile.constant.visitor.ConstantVisitor;
+import proguard.classfile.editor.CodeAttributeEditor;
+import proguard.classfile.editor.ConstantPoolEditor;
+import proguard.classfile.instruction.ConstantInstruction;
+import proguard.classfile.instruction.Instruction;
+import proguard.classfile.instruction.visitor.InstructionVisitor;
+
+public class CallReplacer implements InstructionVisitor {
+    private final CodeAttributeEditor codeAttributeEditor;
+    private final Clazz methodOwnerClazz;
+    private final Method oldMethod;
+    private final Method newMethod;
+
+    public CallReplacer(CodeAttributeEditor codeAttributeEditor, Clazz methodOwnerClazz, Method oldMethod, Method newMethod) {
+        this.codeAttributeEditor = codeAttributeEditor;
+        this.methodOwnerClazz = methodOwnerClazz;
+        this.oldMethod = oldMethod;
+        this.newMethod = newMethod;
+    }
+
+    @Override
+    public void visitAnyInstruction(Clazz clazz, Method method, CodeAttribute codeAttribute, int offset, Instruction instruction) {}
+
+    @Override
+    public void visitConstantInstruction(Clazz clazz, Method method, CodeAttribute codeAttribute, int offset, ConstantInstruction constantInstruction) {
+        if (constantInstruction.opcode == Instruction.OP_INVOKESTATIC) {
+            ConstantPoolEditor constantPoolEditor = new ConstantPoolEditor((ProgramClass) clazz);
+            clazz.constantPoolEntryAccept(constantInstruction.constantIndex, new ConstantVisitor() {
+                @Override
+                public void visitAnyMethodrefConstant(Clazz clazz, AnyMethodrefConstant anyMethodrefConstant) {
+                    if (anyMethodrefConstant.referencedMethod != null && anyMethodrefConstant.referencedMethod.equals(oldMethod)) {
+                        int newMethodIndex = constantPoolEditor.addMethodrefConstant(methodOwnerClazz, newMethod);
+                        codeAttributeEditor.reset(codeAttribute.u4codeLength);
+                        codeAttributeEditor.replaceInstruction(offset, new ConstantInstruction(Instruction.OP_INVOKESTATIC, newMethodIndex));
+                        codeAttributeEditor.visitCodeAttribute(clazz, method, codeAttribute);
+                    }
+                }
+            });
+        }
+    }
+}

--- a/base/src/main/java/proguard/optimize/inline/CannotInlineException.java
+++ b/base/src/main/java/proguard/optimize/inline/CannotInlineException.java
@@ -1,0 +1,7 @@
+package proguard.optimize.inline;
+
+public class CannotInlineException extends RuntimeException {
+    public CannotInlineException(String reason) {
+        super(reason);
+    }
+}

--- a/base/src/main/java/proguard/optimize/inline/CastRemover.java
+++ b/base/src/main/java/proguard/optimize/inline/CastRemover.java
@@ -1,0 +1,75 @@
+package proguard.optimize.inline;
+
+import proguard.classfile.Clazz;
+import proguard.classfile.Method;
+import proguard.classfile.attribute.CodeAttribute;
+import proguard.classfile.constant.AnyMethodrefConstant;
+import proguard.classfile.constant.NameAndTypeConstant;
+import proguard.classfile.constant.visitor.ConstantVisitor;
+import proguard.classfile.editor.CodeAttributeEditor;
+import proguard.classfile.instruction.ConstantInstruction;
+import proguard.classfile.instruction.Instruction;
+import proguard.classfile.instruction.InstructionFactory;
+import proguard.classfile.instruction.VariableInstruction;
+import proguard.classfile.instruction.visitor.InstructionVisitor;
+import proguard.classfile.visitor.ClassPrinter;
+
+import java.util.*;
+
+public class CastRemover implements InstructionVisitor {
+    private final CodeAttributeEditor codeAttributeEditor;
+    private List<Integer> keepList;
+    private int currentIndex;
+
+    public CastRemover(CodeAttributeEditor codeAttributeEditor, List<Integer> keepList) {
+        this.codeAttributeEditor = codeAttributeEditor;
+        this.currentIndex = 0;
+        this.keepList = keepList;
+    }
+
+    public CastRemover(CodeAttributeEditor codeAttributeEditor) {
+        this(codeAttributeEditor, new ArrayList<>());
+    }
+
+    @Override
+    public void visitConstantInstruction(Clazz clazz, Method method, CodeAttribute codeAttribute, int offset, ConstantInstruction constantInstruction) {
+        Set<String> castingMethodNames = new HashSet<>(Arrays.asList("intValue", "booleanValue", "byteValue", "shortValue", "longValue", "floatValue", "doubleValue", "charValue"));
+        if (constantInstruction.opcode == Instruction.OP_CHECKCAST) {
+            System.out.println("Removing " + InstructionFactory.create(codeAttribute.code, offset).toString(offset));
+            codeAttributeEditor.deleteInstruction(offset);
+        } else if (constantInstruction.opcode == Instruction.OP_INVOKESTATIC) {
+            if (getInvokedMethodName(clazz, constantInstruction).equals("valueOf")) {
+                if (!keepList.contains(currentIndex)) {
+                    System.out.print("Removing "); InstructionFactory.create(codeAttribute.code, offset).accept(clazz, method, codeAttribute, offset, new ClassPrinter());
+                    codeAttributeEditor.deleteInstruction(offset);
+                }
+
+                currentIndex++;
+            }
+        } else if (constantInstruction.opcode == Instruction.OP_INVOKEVIRTUAL) {
+            System.out.println("Removing " + InstructionFactory.create(codeAttribute.code, offset).toString(offset));
+            if (castingMethodNames.contains(getInvokedMethodName(clazz, constantInstruction))) {
+                codeAttributeEditor.deleteInstruction(offset);
+            }
+        }
+    }
+
+    @Override
+    public void visitAnyInstruction(Clazz clazz, Method method, CodeAttribute codeAttribute, int offset, Instruction instruction) {
+    }
+
+    private String getInvokedMethodName(Clazz clazz, ConstantInstruction constantInstruction) {
+        final String[] invokedMethodName = new String[1];
+        clazz.constantPoolEntryAccept(constantInstruction.constantIndex, new ConstantVisitor() {
+            @Override public void visitAnyMethodrefConstant(Clazz clazz, AnyMethodrefConstant anyMethodrefConstant) {
+                clazz.constantPoolEntryAccept(anyMethodrefConstant.u2nameAndTypeIndex, new ConstantVisitor() {
+                    @Override
+                    public void visitNameAndTypeConstant(Clazz clazz, NameAndTypeConstant nameAndTypeConstant) {
+                        invokedMethodName[0] = nameAndTypeConstant.getName(clazz);
+                    }
+                });
+            }
+        });
+        return invokedMethodName[0];
+    }
+}

--- a/base/src/main/java/proguard/optimize/inline/DescriptorModifier.java
+++ b/base/src/main/java/proguard/optimize/inline/DescriptorModifier.java
@@ -1,0 +1,50 @@
+package proguard.optimize.inline;
+
+import proguard.classfile.*;
+import proguard.classfile.editor.AttributeAdder;
+import proguard.classfile.editor.ClassBuilder;
+import proguard.classfile.editor.ClassEditor;
+import proguard.obfuscate.NameFactory;
+import proguard.obfuscate.SimpleNameFactory;
+import proguard.obfuscate.UniqueMemberNameFactory;
+import proguard.optimize.info.ProgramMemberOptimizationInfoSetter;
+
+import java.util.function.Function;
+
+public class DescriptorModifier {
+    private final ClassBuilder classBuilder;
+    private final NameFactory nameFactory;
+    private final Clazz clazz;
+
+    DescriptorModifier(Clazz clazz) {
+        classBuilder = new ClassBuilder((ProgramClass) clazz);
+        nameFactory = new UniqueMemberNameFactory(new SimpleNameFactory(), clazz);
+        this.clazz = clazz;
+    }
+    
+    public ProgramMethod modify(ProgramMethod sourceMethod, Function<String, String> modifier) {
+        return modify(sourceMethod, modifier, false);
+    }
+
+    public ProgramMethod modify(ProgramMethod sourceMethod, Function<String, String> modifier, boolean removeOriginal) {
+        ProgramMethod newMethod = classBuilder.addAndReturnMethod(
+                sourceMethod.u2accessFlags,
+                nameFactory.nextName(),
+                modifier.apply(sourceMethod.getDescriptor(clazz))
+        );
+
+        sourceMethod.attributesAccept((ProgramClass) clazz,
+                new AttributeAdder((ProgramClass) clazz, newMethod, true));
+
+        if (removeOriginal)
+            removeOriginal(sourceMethod);
+
+        newMethod.accept(clazz, new ProgramMemberOptimizationInfoSetter());
+        return newMethod;
+    }
+
+    private void removeOriginal(ProgramMethod method) {
+        ClassEditor classEditor = new ClassEditor((ProgramClass) clazz);
+        classEditor.removeMethod(method);
+    }
+}

--- a/base/src/main/java/proguard/optimize/inline/InstructionAtOffset.java
+++ b/base/src/main/java/proguard/optimize/inline/InstructionAtOffset.java
@@ -1,0 +1,45 @@
+package proguard.optimize.inline;
+
+import proguard.classfile.instruction.Instruction;
+
+import java.util.Objects;
+
+public final class InstructionAtOffset {
+    private final Instruction instruction;
+    private final int offset;
+
+    InstructionAtOffset(Instruction instruction, int offset) {
+        this.instruction = instruction;
+        this.offset = offset;
+    }
+
+    public Instruction instruction() {
+        return instruction;
+    }
+
+    public int offset() {
+        return offset;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) return true;
+        if (obj == null || obj.getClass() != this.getClass()) return false;
+        InstructionAtOffset that = (InstructionAtOffset) obj;
+        return Objects.equals(this.instruction, that.instruction) &&
+                this.offset == that.offset;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(instruction, offset);
+    }
+
+    @Override
+    public String toString() {
+        return "InstructionAtOffset[" +
+                "instruction=" + instruction + ", " +
+                "offset=" + offset + ']';
+    }
+
+}

--- a/base/src/main/java/proguard/optimize/inline/LambdaImplementationVisitor.java
+++ b/base/src/main/java/proguard/optimize/inline/LambdaImplementationVisitor.java
@@ -1,0 +1,66 @@
+package proguard.optimize.inline;
+
+import proguard.classfile.*;
+import proguard.classfile.constant.ClassConstant;
+import proguard.classfile.constant.FieldrefConstant;
+import proguard.classfile.constant.visitor.ConstantVisitor;
+import proguard.classfile.visitor.AllMethodVisitor;
+import proguard.classfile.visitor.MemberVisitor;
+
+public class LambdaImplementationVisitor implements ConstantVisitor, MemberVisitor {
+    private final InvokeMethodVisitor invokeMethodVisitor;
+    private Clazz lambdaImplementationClass;
+    public LambdaImplementationVisitor(InvokeMethodVisitor invokeMethodHandler) {
+        this.invokeMethodVisitor = invokeMethodHandler;
+    }
+
+    @Override
+    public void visitFieldrefConstant(Clazz clazz, FieldrefConstant fieldrefConstant) {
+        lambdaImplementationClass = fieldrefConstant.referencedClass;
+        fieldrefConstant.referencedClass.interfaceConstantsAccept(this);
+    }
+
+    @Override
+    public void visitClassConstant(Clazz clazz, ClassConstant referencedClassConstant) {
+        referencedClassConstant.referencedClass.methodsAccept(this);
+    }
+
+    @Override
+    public void visitProgramMethod(ProgramClass interfaceClass, ProgramMethod programMethod)
+    {
+        getLambdaImplementation(interfaceClass, programMethod);
+    }
+
+    @Override
+    public void visitLibraryMethod(LibraryClass interfaceClass, LibraryMethod libraryMethod) {
+        getLambdaImplementation(interfaceClass, libraryMethod);
+    }
+
+    private void getLambdaImplementation(Clazz interfaceClazz, Method method) {
+        String descriptor = method.getDescriptor(interfaceClazz);
+        lambdaImplementationClass.methodAccept("invoke", descriptor, new MemberVisitor() {
+            @Override
+            public void visitProgramMethod(ProgramClass programClass, ProgramMethod programMethod) {
+                System.out.println("Descriptor " + programMethod.getDescriptor(programClass));
+                String descriptor = programMethod.getDescriptor(programClass);
+                lambdaImplementationClass.accept(new AllMethodVisitor(new MemberVisitor() {
+                    @Override
+                    public void visitProgramMethod(ProgramClass programClass, ProgramMethod programMethod) {
+                        if (programMethod.getName(programClass).equals("invoke") && programMethod.u2accessFlags == (AccessConstants.PUBLIC | AccessConstants.FINAL)) {
+                            lambdaImplementationClass.methodAccept("invoke", programMethod.getDescriptor(programClass), new MemberVisitor() {
+                                @Override
+                                public void visitProgramMethod(ProgramClass programClass, ProgramMethod programMethod) {
+                                    invokeMethodVisitor.visitInvokeMethod(programClass, programMethod, interfaceClazz, descriptor);
+                                }
+                            });
+                        }
+                    }
+                }));
+            }
+        });
+    }
+
+    public interface InvokeMethodVisitor {
+        void visitInvokeMethod(ProgramClass programClass, ProgramMethod programMethod, Clazz interfaceClass, String bridgeDescriptor);
+    }
+}

--- a/base/src/main/java/proguard/optimize/inline/LambdaInliner.java
+++ b/base/src/main/java/proguard/optimize/inline/LambdaInliner.java
@@ -1,0 +1,103 @@
+package proguard.optimize.inline;
+
+//import com.guardsquare.gui.Gui;
+import proguard.optimize.inline.lambda_locator.LambdaLocator;
+import proguard.AppView;
+import proguard.classfile.AccessConstants;
+import proguard.classfile.Method;
+import proguard.classfile.ProgramClass;
+import proguard.classfile.editor.CodeAttributeEditor;
+import proguard.classfile.editor.ConstantPoolEditor;
+import proguard.classfile.instruction.ConstantInstruction;
+import proguard.classfile.instruction.Instruction;
+import proguard.classfile.util.InitializationUtil;
+import proguard.optimize.inline.lambda_locator.Lambda;
+import proguard.pass.Pass;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public class LambdaInliner implements Pass {
+    private final String classNameFilter;
+    private boolean inlinedAllUsages;
+    public LambdaInliner(String classNameFilter) {
+        this.classNameFilter = classNameFilter;
+        this.inlinedAllUsages = true;
+    }
+
+    public LambdaInliner() {
+        this("");
+    }
+
+    @Override
+    public void execute(AppView appView) {
+        LambdaLocator lambdaLocator = new LambdaLocator(appView.programClassPool, classNameFilter);
+
+        for (Lambda lambda : lambdaLocator.getStaticLambdas()) {
+            Set<InstructionAtOffset> remainder = new HashSet<>();
+            inlinedAllUsages = true;
+            InitializationUtil.initialize(appView.programClassPool, appView.libraryClassPool);
+            lambda.codeAttribute().accept(lambda.clazz(), lambda.method(), new LambdaUsageFinder(lambda, lambdaLocator.getStaticLambdaMap(), appView, (foundLambda, consumingClass, consumingMethod, consumingCallOffset, consumingCallClazz, consumingCallmethod, consumingCallCodeAttribute, sourceTrace, possibleLambdas) -> {
+                // Try inlining the lambda in consumingMethod
+                BaseLambdaInliner baseLambdaInliner = new BaseLambdaInliner(appView, consumingClass, consumingMethod, lambda);
+                Method inlinedLambamethod = baseLambdaInliner.inline();
+
+                // We didn't inline anything so no need to change any call instructions.
+                if (inlinedLambamethod == null) {
+                    inlinedAllUsages = false;
+                    return;
+                }
+
+                if (possibleLambdas.size() > 1) {
+                    // This lambda is part of a collection of lambdas that might potentially be used, but we do not know which one is actually used. Because of that we cannot inline it.
+                    inlinedAllUsages = false;
+                    return;
+                }
+
+                CodeAttributeEditor codeAttributeEditor = new CodeAttributeEditor();
+                codeAttributeEditor.reset(consumingCallCodeAttribute.u4codeLength);
+
+                /*
+                 * Remove usages that bring the variable on the stack so all the way up until a load
+                 * The store operations before the load might also be used by other functions calls that consume the
+                 * lambda, that's why we need to keep them.
+                 */
+                for (int i = 0; i < sourceTrace.size(); i++) {
+                    InstructionAtOffset instrAtOffset = sourceTrace.get(i);
+                    codeAttributeEditor.deleteInstruction(instrAtOffset.offset());
+                    if (instrAtOffset.instruction().canonicalOpcode() == Instruction.OP_ALOAD || instrAtOffset.instruction().canonicalOpcode() == Instruction.OP_INVOKESTATIC) {
+                        remainder.addAll(sourceTrace.subList(i + 1, sourceTrace.size()));
+                        break;
+                    }
+                }
+
+                // Replace invokestatic call to a call with the new function
+                ConstantPoolEditor constantPoolEditor = new ConstantPoolEditor((ProgramClass) consumingCallClazz);
+                int methodWithoutLambdaParameterIndex = constantPoolEditor.addMethodrefConstant(consumingClass, inlinedLambamethod);
+
+                // Replacing at consumingCallOffset
+                if ((consumingMethod.getAccessFlags() & AccessConstants.STATIC) == 0) {
+                    codeAttributeEditor.replaceInstruction(consumingCallOffset, new ConstantInstruction(Instruction.OP_INVOKEVIRTUAL, methodWithoutLambdaParameterIndex));
+                } else {
+                    codeAttributeEditor.replaceInstruction(consumingCallOffset, new ConstantInstruction(Instruction.OP_INVOKESTATIC, methodWithoutLambdaParameterIndex));
+                }
+
+                codeAttributeEditor.visitCodeAttribute(consumingCallClazz, consumingCallmethod, consumingCallCodeAttribute);
+            }));
+
+            /*
+             * Only remove the code needed to obtain a reference to the lambda if we were able to inline everything, if we
+             * could not do that then we still need the lambda and cannot remove it.
+             */
+            if (inlinedAllUsages) {
+                // Removing lambda obtaining code because all usages could be inlined!
+                CodeAttributeEditor codeAttributeEditor = new CodeAttributeEditor();
+                codeAttributeEditor.reset(lambda.codeAttribute().u4codeLength);
+                for (InstructionAtOffset instrAtOffset : remainder) {
+                    codeAttributeEditor.deleteInstruction(instrAtOffset.offset());
+                }
+                codeAttributeEditor.visitCodeAttribute(lambda.clazz(), lambda.method(), lambda.codeAttribute());
+            }
+        }
+    }
+}

--- a/base/src/main/java/proguard/optimize/inline/LambdaUsageFinder.java
+++ b/base/src/main/java/proguard/optimize/inline/LambdaUsageFinder.java
@@ -1,0 +1,172 @@
+package proguard.optimize.inline;
+
+import proguard.optimize.inline.lambda_locator.LambdaLocator;
+import proguard.AppView;
+import proguard.classfile.AccessConstants;
+import proguard.classfile.Clazz;
+import proguard.classfile.Method;
+import proguard.classfile.attribute.CodeAttribute;
+import proguard.classfile.attribute.visitor.AllAttributeVisitor;
+import proguard.classfile.attribute.visitor.AttributeVisitor;
+import proguard.classfile.constant.FieldrefConstant;
+import proguard.classfile.constant.MethodrefConstant;
+import proguard.classfile.constant.visitor.ConstantVisitor;
+import proguard.classfile.instruction.ConstantInstruction;
+import proguard.classfile.instruction.Instruction;
+import proguard.classfile.instruction.SimpleInstruction;
+import proguard.classfile.instruction.visitor.AllInstructionVisitor;
+import proguard.classfile.instruction.visitor.InstructionOpCodeFilter;
+import proguard.classfile.instruction.visitor.InstructionVisitor;
+import proguard.classfile.util.ClassUtil;
+import proguard.classfile.visitor.ClassPrinter;
+import proguard.evaluation.PartialEvaluator;
+import proguard.evaluation.TracedStack;
+import proguard.optimize.inline.lambda_locator.Lambda;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+public class LambdaUsageFinder implements InstructionVisitor, AttributeVisitor, ConstantVisitor {
+    private final Lambda targetLambda;
+    private PartialEvaluator partialEvaluator;
+    private final Map<Integer, Lambda> lambdaMap;
+    private final AppView appView;
+    private final LambdaUsageHandler lambdaUsageHandler;
+    public MethodrefConstant methodrefConstant;
+    public FieldrefConstant referencedFieldConstant;
+    private final boolean inlineFromFields;
+    private final boolean inlineFromMethods;
+    private final int[] typedReturnInstructions = new int[] {
+        Instruction.OP_IRETURN,
+        Instruction.OP_LRETURN,
+        Instruction.OP_FRETURN,
+        Instruction.OP_DRETURN,
+        Instruction.OP_ARETURN
+    };
+
+    public LambdaUsageFinder(Lambda targetLambda, Map<Integer, Lambda> lambdaMap, AppView appView, boolean inlineFromFields, boolean inlineFromMethods, LambdaUsageHandler lambdaUsageHandler) {
+        this.targetLambda = targetLambda;
+        this.partialEvaluator = new PartialEvaluator();
+        this.lambdaMap = lambdaMap;
+        this.appView = appView;
+        this.lambdaUsageHandler = lambdaUsageHandler;
+        this.inlineFromFields = inlineFromFields;
+        this.inlineFromMethods = inlineFromMethods;
+    }
+
+    public LambdaUsageFinder(Lambda targetLambda, Map<Integer, Lambda> lambdaMap, AppView appView, LambdaUsageHandler lambdaUsageHandler) {
+        this(targetLambda, lambdaMap, appView, false, false, lambdaUsageHandler);
+    }
+
+    @Override
+    public void visitCodeAttribute(Clazz clazz, Method method, CodeAttribute codeAttribute) {
+        partialEvaluator.visitCodeAttribute(clazz, method, codeAttribute);
+        codeAttribute.instructionsAccept(clazz, method,
+                new InstructionOpCodeFilter(
+                        new int[] {
+                            Instruction.OP_INVOKESTATIC,
+                            Instruction.OP_INVOKEVIRTUAL,
+                            Instruction.OP_IRETURN,
+                            Instruction.OP_LRETURN,
+                            Instruction.OP_FRETURN,
+                            Instruction.OP_DRETURN,
+                            Instruction.OP_ARETURN
+                        },
+                        this
+                )
+        );
+    }
+
+    @Override
+    public void visitAnyInstruction(Clazz clazz, Method method, CodeAttribute codeAttribute, int offset, Instruction instruction) {}
+
+    @Override
+    public void visitConstantInstruction(Clazz clazz, Method method, CodeAttribute codeAttribute, int offset, ConstantInstruction constantInstruction) {
+        // We deleted instructions while iterating, the loop however cannot read the new codeAttribute.u4codeLength value so we must stop it manually!
+        if (offset >= codeAttribute.u4codeLength) {
+            return;
+        }
+        findUsage(clazz, method, codeAttribute, constantInstruction, offset, this::isTargetLambda);
+    }
+
+    @Override
+    public void visitSimpleInstruction(Clazz clazz, Method method, CodeAttribute codeAttribute, int offset, SimpleInstruction simpleInstruction) {}
+
+    private void findUsage(Clazz clazz, Method method, CodeAttribute codeAttribute, ConstantInstruction consumingMethodCallInstruction, int offset, Function<InstructionAtOffset, Boolean> condition) {
+        System.out.println("--------Start----------");
+        System.out.println(consumingMethodCallInstruction);
+
+        clazz.constantPoolEntryAccept(consumingMethodCallInstruction.constantIndex, this);
+
+        partialEvaluator = new PartialEvaluator();
+        partialEvaluator.visitCodeAttribute(clazz, method, codeAttribute);
+        TracedStack tracedStack = partialEvaluator.getStackBefore(offset);
+        System.out.println(tracedStack);
+
+        System.out.println(methodrefConstant.referencedMethod.getDescriptor(methodrefConstant.referencedClass));
+        String methodDescriptor = methodrefConstant.referencedMethod.getDescriptor(methodrefConstant.referencedClass);
+        int argCount = ClassUtil.internalMethodParameterCount(methodDescriptor);
+        for (int argIndex = 0; argIndex < argCount; argIndex++) {
+            int stackAdjustedIndex = ClassUtil.internalMethodVariableIndex(methodDescriptor, true, argIndex);
+            int traceOffset = tracedStack.getBottomActualProducerValue(tracedStack.size() - ClassUtil.internalMethodVariableIndex(methodDescriptor, true, argCount) + stackAdjustedIndex).instructionOffsetValue().instructionOffset(0);
+            List<InstructionAtOffset> trace = Util.traceParameterOffset(partialEvaluator, codeAttribute, traceOffset);
+            List<InstructionAtOffset> leafNodes = new ArrayList<>();
+            Util.traceParameterTree(partialEvaluator, codeAttribute, traceOffset, leafNodes);
+            boolean match = false;
+            for (InstructionAtOffset tracedInstructionAtOffset : leafNodes) {
+                System.out.println("Argument " + argIndex + " source " + tracedInstructionAtOffset);
+                if (condition.apply(tracedInstructionAtOffset)) {
+                    codeAttribute.accept(clazz, method, new ClassPrinter());
+                    System.out.println("Lambda " + targetLambda + " consumed by " + methodrefConstant.referencedMethod.getName(methodrefConstant.referencedClass));
+                    match = true;
+                    break;
+                }
+            }
+
+            if (match) {
+                lambdaUsageHandler.handle(
+                    targetLambda,
+                    methodrefConstant.referencedClass,
+                    methodrefConstant.referencedMethod,
+                    offset,
+                    clazz,
+                    method,
+                    codeAttribute,
+                    trace,
+                    leafNodes.stream().filter(it -> it.instruction().opcode == Instruction.OP_GETSTATIC).map(it -> {
+                        ConstantInstruction getStaticInstruction = (ConstantInstruction) it.instruction();
+                        return lambdaMap.get(getStaticInstruction.constantIndex);
+                    }).collect(Collectors.toList())
+                );
+            }
+        }
+        System.out.println("---------End-----------");
+    }
+
+    private boolean isTargetLambda(InstructionAtOffset instructionAtOffset) {
+        if (instructionAtOffset.instruction().opcode == Instruction.OP_GETSTATIC) {
+            ConstantInstruction constantInstruction = (ConstantInstruction) instructionAtOffset.instruction();
+            Lambda lambda = lambdaMap.get(constantInstruction.constantIndex);
+            return lambda != null && lambda.equals(targetLambda);
+        }
+        return false;
+    }
+
+    @Override
+    public void visitMethodrefConstant(Clazz clazz, MethodrefConstant methodrefConstant) {
+        this.methodrefConstant = methodrefConstant;
+    }
+
+    @Override
+    public void visitFieldrefConstant(Clazz clazz, FieldrefConstant fieldrefConstant) {
+        this.referencedFieldConstant = fieldrefConstant;
+    }
+
+    public interface LambdaUsageHandler {
+        void handle(Lambda lambda, Clazz consumingClazz, Method consumingMethod, int consumingCallOffset, Clazz consumingCallClass, Method consumingCallMethod, CodeAttribute consumingCallCodeAttribute, List<InstructionAtOffset> sourceTrace, List<Lambda> possibleLambdas);
+    }
+}

--- a/base/src/main/java/proguard/optimize/inline/LocalUsageRemover.java
+++ b/base/src/main/java/proguard/optimize/inline/LocalUsageRemover.java
@@ -1,0 +1,56 @@
+package proguard.optimize.inline;
+
+import proguard.classfile.Clazz;
+import proguard.classfile.Method;
+import proguard.classfile.ProgramClass;
+import proguard.classfile.ProgramMethod;
+import proguard.classfile.attribute.Attribute;
+import proguard.classfile.attribute.CodeAttribute;
+import proguard.classfile.attribute.visitor.AllAttributeVisitor;
+import proguard.classfile.attribute.visitor.AttributeVisitor;
+import proguard.classfile.editor.CodeAttributeEditor;
+import proguard.classfile.instruction.Instruction;
+import proguard.classfile.instruction.VariableInstruction;
+import proguard.classfile.instruction.visitor.InstructionVisitor;
+import proguard.classfile.visitor.MemberVisitor;
+
+public class LocalUsageRemover implements MemberVisitor {
+    private final CodeAttributeEditor codeAttributeEditor;
+    private final int argumentIndex;
+
+    public LocalUsageRemover(CodeAttributeEditor codeAttributeEditor, int argumentIndex) {
+        this.codeAttributeEditor = codeAttributeEditor;
+        this.argumentIndex = argumentIndex;
+    }
+
+    @Override
+    public void visitProgramMethod(ProgramClass programClass, ProgramMethod programMethod) {
+        programMethod.accept(programClass, new AllAttributeVisitor(new AttributeVisitor() {
+            @Override
+            public void visitAnyAttribute(Clazz clazz, Attribute attribute) {}
+
+            @Override
+            public void visitCodeAttribute(Clazz clazz, Method method, CodeAttribute codeAttribute) {
+                codeAttributeEditor.reset(codeAttribute.u4codeLength);
+                codeAttribute.instructionsAccept(clazz, method, new InstructionVisitor() {
+                    @Override
+                    public void visitAnyInstruction(Clazz clazz, Method method, CodeAttribute codeAttribute, int offset, Instruction instruction) {}
+
+                    @Override
+                    public void visitVariableInstruction(Clazz clazz, Method method, CodeAttribute codeAttribute, int offset, VariableInstruction variableInstruction) {
+                        if (variableInstruction.variableIndex == argumentIndex) {
+                            if (variableInstruction.isStore()) {
+                                codeAttributeEditor.replaceInstruction(offset, new VariableInstruction(Instruction.OP_POP));
+                            } else {
+                                codeAttributeEditor.replaceInstruction(offset, new VariableInstruction(Instruction.OP_ACONST_NULL));
+                            }
+                        } else if (variableInstruction.variableIndex > argumentIndex){
+                            codeAttributeEditor.replaceInstruction(offset, new VariableInstruction(variableInstruction.canonicalOpcode(), variableInstruction.variableIndex - 1, variableInstruction.constant));
+                        }
+                    }
+                });
+                codeAttributeEditor.visitCodeAttribute(clazz, method, codeAttribute);
+            }
+        }));
+    }
+}

--- a/base/src/main/java/proguard/optimize/inline/MethodInstructionVisitor.java
+++ b/base/src/main/java/proguard/optimize/inline/MethodInstructionVisitor.java
@@ -1,0 +1,41 @@
+package proguard.optimize.inline;
+
+import proguard.classfile.Clazz;
+import proguard.classfile.Method;
+import proguard.classfile.ProgramClass;
+import proguard.classfile.ProgramMethod;
+import proguard.classfile.attribute.Attribute;
+import proguard.classfile.attribute.CodeAttribute;
+import proguard.classfile.attribute.visitor.AttributeVisitor;
+import proguard.classfile.instruction.visitor.InstructionVisitor;
+import proguard.classfile.visitor.MemberVisitor;
+
+public class MethodInstructionVisitor implements MemberVisitor, AttributeVisitor {
+    private final InstructionVisitor instructionVisitor;
+    private final int startOffset;
+    private final int endOffset;
+
+    public MethodInstructionVisitor(int startOffset, int endOffset, InstructionVisitor instructionVisitor) {
+        this.instructionVisitor = instructionVisitor;
+        this.startOffset = startOffset;
+        this.endOffset = endOffset;
+    }
+
+    public MethodInstructionVisitor(InstructionVisitor instructionVisitor) {
+        this(-1, -1, instructionVisitor);
+    }
+
+    @Override
+    public void visitProgramMethod(ProgramClass programClass, ProgramMethod programMethod) {
+        programMethod.attributesAccept(programClass, this);
+    }
+
+    @Override
+    public void visitAnyAttribute(Clazz clazz, Attribute attribute) {}
+
+    @Override
+    public void visitCodeAttribute(Clazz clazz, Method method, CodeAttribute codeAttribute) {
+        if (startOffset < 0) codeAttribute.instructionsAccept(clazz, method, instructionVisitor);
+        else codeAttribute.instructionsAccept(clazz, method, startOffset, endOffset, instructionVisitor);
+    }
+}

--- a/base/src/main/java/proguard/optimize/inline/MethodUsageFinder.java
+++ b/base/src/main/java/proguard/optimize/inline/MethodUsageFinder.java
@@ -1,0 +1,66 @@
+package proguard.optimize.inline;
+
+import proguard.classfile.Clazz;
+import proguard.classfile.Method;
+import proguard.classfile.ProgramClass;
+import proguard.classfile.ProgramMethod;
+import proguard.classfile.attribute.CodeAttribute;
+import proguard.classfile.attribute.visitor.AllAttributeVisitor;
+import proguard.classfile.constant.visitor.ConstantVisitor;
+import proguard.classfile.instruction.ConstantInstruction;
+import proguard.classfile.instruction.Instruction;
+import proguard.classfile.instruction.visitor.AllInstructionVisitor;
+import proguard.classfile.instruction.visitor.InstructionOpCodeFilter;
+import proguard.classfile.instruction.visitor.InstructionVisitor;
+import proguard.classfile.visitor.ClassVisitor;
+import proguard.classfile.visitor.MemberVisitor;
+
+/**
+ * A class that searches the entire class pool for calls  to a specific method.
+ */
+public class MethodUsageFinder implements ClassVisitor, MemberVisitor, InstructionVisitor, ConstantVisitor {
+    private final Method targetMethod;
+    private final UsingMethodHandler usageHandler;
+
+    public MethodUsageFinder(Method targetMethod, UsingMethodHandler usageHandler) {
+        this.targetMethod = targetMethod;
+        this.usageHandler = usageHandler;
+    }
+
+    @Override
+    public void visitAnyClass(Clazz clazz) {}
+
+    @Override
+    public void visitProgramClass(ProgramClass programClass) {
+        programClass.methodsAccept(this);
+    }
+
+    @Override
+    public void visitProgramMethod(ProgramClass programClass, ProgramMethod programMethod) {
+        programMethod.accept(programClass,
+            new AllAttributeVisitor(
+            new AllInstructionVisitor(
+            new InstructionOpCodeFilter(
+                new int[] {
+                    Instruction.OP_INVOKESTATIC,
+                    Instruction.OP_INVOKEVIRTUAL,
+                    Instruction.OP_INVOKESPECIAL
+                },
+                this
+            )))
+        );
+    }
+
+    @Override
+    public void visitConstantInstruction(Clazz consumingCallClazz, Method possibleMethodUser, CodeAttribute codeAttribute, int offset, ConstantInstruction constantInstruction) {
+        Method referencedMethod = new RefMethodFinder(consumingCallClazz).findReferencedMethod(constantInstruction);
+        if (referencedMethod != null && referencedMethod.equals(targetMethod)) {
+            System.out.println("Found a user, method " + possibleMethodUser.getName(consumingCallClazz) + " in class " + consumingCallClazz.getName());
+            usageHandler.handle(consumingCallClazz, possibleMethodUser, constantInstruction, offset);
+        }
+    }
+
+    public interface UsingMethodHandler {
+        void handle(Clazz clazz, Method method, ConstantInstruction constantInstruction, int offset);
+    }
+}

--- a/base/src/main/java/proguard/optimize/inline/Node.java
+++ b/base/src/main/java/proguard/optimize/inline/Node.java
@@ -1,0 +1,33 @@
+package proguard.optimize.inline;
+
+import java.util.List;
+import java.util.Objects;
+
+public final class Node {
+    public InstructionAtOffset value;
+    public List<Node> children;
+
+    Node(InstructionAtOffset value, List<Node> children) {
+        this.value = value;
+        this.children = children;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) return true;
+        if (obj == null || obj.getClass() != this.getClass()) return false;
+        Node that = (Node) obj;
+        return Objects.equals(this.value, that.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(value);
+    }
+
+    @Override
+    public String toString() {
+        return "Node[" +
+                "value=" + value + ']';
+    }
+}

--- a/base/src/main/java/proguard/optimize/inline/NullCheckRemover.java
+++ b/base/src/main/java/proguard/optimize/inline/NullCheckRemover.java
@@ -1,0 +1,75 @@
+package proguard.optimize.inline;
+
+import proguard.classfile.Clazz;
+import proguard.classfile.Method;
+import proguard.classfile.attribute.CodeAttribute;
+import proguard.classfile.constant.Constant;
+import proguard.classfile.constant.MethodrefConstant;
+import proguard.classfile.constant.visitor.ConstantVisitor;
+import proguard.classfile.editor.CodeAttributeEditor;
+import proguard.classfile.editor.InstructionSequenceBuilder;
+import proguard.classfile.instruction.Instruction;
+import proguard.classfile.instruction.InstructionFactory;
+import proguard.classfile.instruction.visitor.InstructionVisitor;
+import proguard.classfile.util.InstructionSequenceMatcher;
+
+class NullCheckRemover implements InstructionVisitor {
+    private final InstructionSequenceMatcher insSeqMatcher;
+    private final int X = InstructionSequenceMatcher.X;
+    private final int Y = InstructionSequenceMatcher.Y;
+    private final int C = InstructionSequenceMatcher.C;
+    private final Instruction[] pattern;
+    Constant[] constants;
+    private final int argumentIndex;
+    private final InstructionVisitor extraInstructionVisitor;
+
+    public NullCheckRemover(int argumentIndex, InstructionVisitor extraInstructionVisitor) {
+        InstructionSequenceBuilder ____ =
+                new InstructionSequenceBuilder();
+
+        pattern = ____.aload(X)
+            .ldc_(C)
+            .invokestatic(Y).__();
+
+        constants = ____.constants();
+
+        this.insSeqMatcher = new InstructionSequenceMatcher(constants, pattern);
+        this.argumentIndex = argumentIndex;
+        this.extraInstructionVisitor = extraInstructionVisitor;
+    }
+
+    public NullCheckRemover(int argumentIndex) {
+        this(argumentIndex, null);
+    }
+
+    public void visitAnyInstruction(Clazz clazz, Method method, CodeAttribute codeAttribute, int offset, Instruction instruction) {
+        //System.out.println(instruction.toString(clazz, offset));
+        instruction.accept(clazz, method, codeAttribute, offset, insSeqMatcher);
+        if (insSeqMatcher.isMatching() && insSeqMatcher.matchedConstantIndex(X) == argumentIndex) {
+            //System.out.println("  -> matching sequence starting at [" + insSeqMatcher.matchedInstructionOffset(0) + "]");
+
+            insSeqMatcher.matchedConstantIndex(Y);
+            clazz.constantPoolEntryAccept(insSeqMatcher.matchedArgument(Y), new ConstantVisitor() {
+                @Override
+                public void visitMethodrefConstant(Clazz clazz, MethodrefConstant methodrefConstant) {
+                    // Check if the called function matches kotlin.jvm.internal.Intrinsics#void checkNotNullParameter(java.lang.Object,java.lang.String)
+                    if (
+                        methodrefConstant.getClassName(clazz).equals("kotlin/jvm/internal/Intrinsics") &&
+                        methodrefConstant.getName(clazz).equals("checkNotNullParameter") &&
+                        methodrefConstant.getType(clazz).equals("(Ljava/lang/Object;Ljava/lang/String;)V")
+                    ) {
+                        CodeAttributeEditor codeAttributeEditor = new CodeAttributeEditor();
+                        codeAttributeEditor.reset(codeAttribute.u4codeLength);
+                        for (int insIndex = 0; insIndex < pattern.length; insIndex++) {
+                            int insOffset = insSeqMatcher.matchedInstructionOffset(insIndex);
+                            if (extraInstructionVisitor != null)
+                                extraInstructionVisitor.visitAnyInstruction(clazz, method, codeAttribute, insSeqMatcher.matchedInstructionOffset(insIndex), InstructionFactory.create(codeAttribute.code, insOffset));
+                            codeAttributeEditor.deleteInstruction(insOffset);
+                        }
+                        codeAttributeEditor.visitCodeAttribute(clazz, method, codeAttribute);
+                    }
+                }
+            });
+        }
+    }
+}

--- a/base/src/main/java/proguard/optimize/inline/RecursiveInliner.java
+++ b/base/src/main/java/proguard/optimize/inline/RecursiveInliner.java
@@ -1,0 +1,141 @@
+package proguard.optimize.inline;
+
+import proguard.optimize.inline.lambda_locator.LambdaLocator;
+import proguard.AppView;
+import proguard.classfile.*;
+import proguard.classfile.attribute.Attribute;
+import proguard.classfile.attribute.CodeAttribute;
+import proguard.classfile.attribute.visitor.AttributeVisitor;
+import proguard.classfile.constant.MethodrefConstant;
+import proguard.classfile.constant.visitor.ConstantVisitor;
+import proguard.classfile.editor.ClassEditor;
+import proguard.classfile.editor.CodeAttributeEditor;
+import proguard.classfile.editor.ConstantPoolEditor;
+import proguard.classfile.instruction.ConstantInstruction;
+import proguard.classfile.instruction.Instruction;
+import proguard.classfile.instruction.VariableInstruction;
+import proguard.classfile.instruction.visitor.InstructionOpCodeFilter;
+import proguard.classfile.instruction.visitor.InstructionVisitor;
+import proguard.classfile.util.ClassReferenceInitializer;
+import proguard.classfile.util.ClassUtil;
+import proguard.classfile.visitor.ClassPrinter;
+import proguard.classfile.visitor.MemberVisitor;
+import proguard.evaluation.PartialEvaluator;
+import proguard.evaluation.TracedStack;
+import proguard.optimize.inline.lambda_locator.Lambda;
+
+/**
+ * Recursively inline functions that make use of the lambda parameter in the arguments of the current function.
+ * The first step, is finding out who actually uses our lambda parameter, we do this using the partial evaluator.
+ */
+public class RecursiveInliner implements AttributeVisitor, InstructionVisitor, MemberVisitor {
+    private final AppView appView;
+    private Clazz consumingClazz;
+    private Method copiedConsumingMethod;
+    private final Method originalConsumingMethod;
+    private final boolean isStatic;
+    private final Lambda lambda;
+    private final boolean enableRecursiveMerging;
+    private final PartialEvaluator partialEvaluator;
+    private Clazz referencedClass;
+    private Method referencedMethod;
+    private int callOffset;
+
+    /**
+     * @param originalConsumingMethod The original consuming method reference, this is used to detect recursion.
+     */
+    public RecursiveInliner(AppView appView, Method originalConsumingMethod, Lambda lambda, boolean enableRecursiveMerging) {
+        this.appView = appView;
+        this.consumingClazz = null;
+        this.copiedConsumingMethod = null;
+        this.originalConsumingMethod = originalConsumingMethod;
+        this.isStatic = (originalConsumingMethod.getAccessFlags() & AccessConstants.STATIC) != 0;
+        this.lambda = lambda;
+        this.enableRecursiveMerging = enableRecursiveMerging;
+        this.partialEvaluator = new PartialEvaluator();
+        this.referencedMethod = null;
+    }
+
+    public RecursiveInliner(AppView appView, Method originalConsumingMethod, Lambda lambda) {
+        this(appView, originalConsumingMethod, lambda, false);
+    }
+
+    @Override
+    public void visitAnyAttribute(Clazz clazz, Attribute attribute) {}
+
+    @Override
+    public void visitCodeAttribute(Clazz clazz, Method method, CodeAttribute codeAttribute) {
+        codeAttribute.accept(clazz, method, new ClassPrinter());
+        partialEvaluator.visitCodeAttribute(clazz, method, codeAttribute);
+        codeAttribute.instructionsAccept(clazz, method,
+            new InstructionOpCodeFilter(new int[] {Instruction.OP_INVOKESTATIC, Instruction.OP_INVOKEVIRTUAL, Instruction.OP_INVOKESPECIAL},
+            new InstructionVisitor() {
+                @Override
+                public void visitConstantInstruction(Clazz clazz, Method method, CodeAttribute codeAttribute, int offset, ConstantInstruction constantInstruction) {
+                    System.out.println("At " + constantInstruction);
+                    TracedStack tracedStack = partialEvaluator.getStackBefore(offset);
+
+                    if (tracedStack == null)
+                        return;
+
+                    System.out.println("Stack size " + tracedStack.size());
+                    if (tracedStack.size() <= 0)
+                        return;
+
+                    clazz.constantPoolEntryAccept(constantInstruction.constantIndex, new ConstantVisitor() {
+                        @Override
+                        public void visitMethodrefConstant(Clazz clazz, MethodrefConstant methodrefConstant) {
+                            if (methodrefConstant.getClassName(clazz).equals("kotlin/jvm/internal/Intrinsics") &&
+                                    methodrefConstant.getName(clazz).equals("checkNotNullParameter") &&
+                                    methodrefConstant.getType(clazz).equals("(Ljava/lang/Object;Ljava/lang/String;)V"))
+                                return;
+
+                            String methodDescriptor = methodrefConstant.referencedMethod.getDescriptor(methodrefConstant.referencedClass);
+                            int argCount = ClassUtil.internalMethodParameterCount(methodDescriptor);
+                            boolean referencedMethodStatic = (methodrefConstant.referencedMethod.getAccessFlags() & AccessConstants.STATIC) != 0;
+                            // We will now check if any of the arguments has a value that comes from the lambda parameters
+                            for (int argIndex = 0; argIndex < argCount; argIndex++) {
+                                int stackAdjustedIndex = ClassUtil.internalMethodVariableIndex(methodDescriptor, referencedMethodStatic, argIndex);
+                                int traceOffset = tracedStack.getBottomActualProducerValue(tracedStack.size() - ClassUtil.internalMethodVariableIndex(methodDescriptor, referencedMethodStatic, argCount) + stackAdjustedIndex).instructionOffsetValue().instructionOffset(0);
+                                referencedMethod = methodrefConstant.referencedMethod;
+                                referencedClass = methodrefConstant.referencedClass;
+                                callOffset = offset;
+                                codeAttribute.instructionAccept(clazz, method, traceOffset, RecursiveInliner.this);
+                            }
+                        }
+                    });
+                }
+        }));
+    }
+
+    @Override
+    public void visitAnyInstruction(Clazz clazz, Method method, CodeAttribute codeAttribute, int offset, Instruction instruction) {}
+
+    @Override
+    public void visitVariableInstruction(Clazz clazz, Method method, CodeAttribute codeAttribute, int offset, VariableInstruction variableInstruction) {
+        if (variableInstruction.canonicalOpcode() == Instruction.OP_ALOAD) {
+            System.out.println("Value from " + variableInstruction + " " + variableInstruction.variableIndex);
+
+            Instruction sourceInstruction = Util.traceParameter(partialEvaluator, codeAttribute, offset);
+            System.out.println(variableInstruction + " gets it's value from " + sourceInstruction);
+            if (sourceInstruction.canonicalOpcode() == Instruction.OP_ALOAD) {
+                VariableInstruction variableSourceInstruction = (VariableInstruction) sourceInstruction;
+
+                String consumingMethodDescriptor = copiedConsumingMethod.getDescriptor(consumingClazz);
+                int calledLambdaRealIndex = Util.findFirstLambdaParameter(consumingMethodDescriptor);
+                int sizeAdjustedLambdaIndex = ClassUtil.internalMethodVariableIndex(consumingMethodDescriptor, isStatic, calledLambdaRealIndex);
+
+                if (variableSourceInstruction.variableIndex == sizeAdjustedLambdaIndex) {
+                    throw new CannotInlineException("Cannot inline lambda into recursive function");
+                }
+            }
+        }
+    }
+
+    @Override
+    public void visitProgramMethod(ProgramClass programClass, ProgramMethod programMethod) {
+        this.consumingClazz = programClass;
+        this.copiedConsumingMethod = programMethod;
+        programMethod.attributesAccept(programClass, this);
+    }
+}

--- a/base/src/main/java/proguard/optimize/inline/RefMethodFinder.java
+++ b/base/src/main/java/proguard/optimize/inline/RefMethodFinder.java
@@ -1,0 +1,32 @@
+package proguard.optimize.inline;
+
+import proguard.classfile.Clazz;
+import proguard.classfile.Member;
+import proguard.classfile.Method;
+import proguard.classfile.ProgramClass;
+import proguard.classfile.ProgramMethod;
+import proguard.classfile.instruction.ConstantInstruction;
+import proguard.classfile.visitor.MemberVisitor;
+import proguard.classfile.visitor.ReferencedMemberVisitor;
+
+public class RefMethodFinder {
+    private final Clazz clazz;
+    private Method foundMethod;
+    public RefMethodFinder(Clazz clazz) {
+        this.clazz = clazz;
+        this.foundMethod = null;
+    }
+
+    public Method findReferencedMethod(ConstantInstruction constantInstruction) {
+        clazz.constantPoolEntryAccept(constantInstruction.constantIndex, new ReferencedMemberVisitor(new MemberVisitor() {
+            @Override
+            public void visitAnyMember(Clazz clazz, Member member) {}
+
+            @Override
+            public void visitProgramMethod(ProgramClass programClass, ProgramMethod programMethod) {
+                foundMethod = programMethod;
+            }
+        }));
+        return foundMethod;
+    }
+}

--- a/base/src/main/java/proguard/optimize/inline/Util.java
+++ b/base/src/main/java/proguard/optimize/inline/Util.java
@@ -1,0 +1,167 @@
+package proguard.optimize.inline;
+
+import proguard.classfile.Clazz;
+import proguard.classfile.Method;
+import proguard.classfile.attribute.CodeAttribute;
+import proguard.classfile.attribute.visitor.AllAttributeVisitor;
+import proguard.classfile.instruction.Instruction;
+import proguard.classfile.instruction.InstructionFactory;
+import proguard.classfile.instruction.VariableInstruction;
+import proguard.classfile.instruction.visitor.AllInstructionVisitor;
+import proguard.classfile.instruction.visitor.InstructionVisitor;
+import proguard.classfile.util.InternalTypeEnumeration;
+import proguard.classfile.visitor.ClassPrinter;
+import proguard.evaluation.PartialEvaluator;
+import proguard.evaluation.TracedStack;
+import proguard.evaluation.value.InstructionOffsetValue;
+import proguard.optimize.peephole.MethodInliner;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class Util {
+    /**
+     * Given an offset of an instruction, trace the source producer value.
+     */
+    public static Instruction traceParameter(PartialEvaluator partialEvaluator, CodeAttribute codeAttribute, int offset) {
+        List<InstructionAtOffset> trace = traceParameterOffset(partialEvaluator, codeAttribute, offset);
+        return trace.get(trace.size() - 1).instruction();
+    }
+
+    public static List<InstructionAtOffset> traceParameterOffset(PartialEvaluator partialEvaluator, CodeAttribute codeAttribute, int offset) {
+        List<InstructionAtOffset> trace = new ArrayList<>();
+        TracedStack currentTracedStack;
+        int currentOffset = offset;
+        Instruction currentInstruction = InstructionFactory.create(codeAttribute.code, currentOffset);
+        trace.add(new InstructionAtOffset(currentInstruction, currentOffset));
+
+        // Maybe make use of stackPopCount, if an instruction doesn't pop anything from the stack then it is the producer?
+        while (
+                (!isLoad(currentInstruction) ||
+                        !partialEvaluator.getVariablesBefore(currentOffset).getProducerValue(((VariableInstruction) currentInstruction).variableIndex).instructionOffsetValue().isMethodParameter(0)) &&
+                        currentInstruction.opcode != Instruction.OP_ACONST_NULL &&
+                        currentInstruction.canonicalOpcode() != Instruction.OP_ICONST_0 &&
+                        currentInstruction.opcode != Instruction.OP_LDC &&
+                        currentInstruction.opcode != Instruction.OP_LDC_W &&
+                        currentInstruction.opcode != Instruction.OP_LDC2_W &&
+                        currentInstruction.opcode != Instruction.OP_NEW &&
+                        currentInstruction.opcode != Instruction.OP_GETSTATIC &&
+                        currentInstruction.opcode != Instruction.OP_INVOKESTATIC &&
+                        currentInstruction.opcode != Instruction.OP_INVOKEVIRTUAL &&
+                        currentInstruction.opcode != Instruction.OP_GETFIELD
+        ) {
+            System.out.println(currentInstruction.toString(currentOffset));
+            currentTracedStack = partialEvaluator.getStackBefore(currentOffset);
+            System.out.println(currentTracedStack);
+
+            // There is no stack value, it's coming from the variables
+            if (isLoad(currentInstruction)) {
+                InstructionOffsetValue offsetValue = partialEvaluator.getVariablesBefore(currentOffset).getProducerValue(((VariableInstruction) currentInstruction).variableIndex).instructionOffsetValue();
+                // There are multiple sources, we don't know which one! We could in the future return a tree instead of just null if  that would be useful.
+                if (offsetValue.instructionOffsetCount() > 1) {
+                    return null;
+                }
+                currentOffset = offsetValue.instructionOffset(0);
+            } else {
+                currentOffset = currentTracedStack.getTopActualProducerValue(0).instructionOffsetValue().instructionOffset(0);
+            }
+            currentInstruction = InstructionFactory.create(codeAttribute.code, currentOffset);
+            trace.add(new InstructionAtOffset(currentInstruction, currentOffset));
+        }
+        return trace;
+    }
+
+    public static boolean isLoad(Instruction instruction) {
+        return instruction.getClass().equals(VariableInstruction.class) && ((VariableInstruction) instruction).isLoad();
+    }
+
+    public static Node traceParameterTree(PartialEvaluator partialEvaluator, CodeAttribute codeAttribute, int offset, List<InstructionAtOffset> leafNodes) {
+        TracedStack currentTracedStack;
+        Instruction currentInstruction = InstructionFactory.create(codeAttribute.code, offset);
+        Node root = new Node(new InstructionAtOffset(currentInstruction, offset), new ArrayList<>());
+
+        // Maybe make use of stackPopCount, if an instruction doesn't pop anything from the stack then it is the producer?
+        if (
+                (!isLoad(currentInstruction) ||
+                        !partialEvaluator.getVariablesBefore(offset).getProducerValue(((VariableInstruction) currentInstruction).variableIndex).instructionOffsetValue().isMethodParameter(0)) &&
+                        currentInstruction.opcode != Instruction.OP_ACONST_NULL &&
+                        currentInstruction.canonicalOpcode() != Instruction.OP_ICONST_0 &&
+                        currentInstruction.opcode != Instruction.OP_LDC &&
+                        currentInstruction.opcode != Instruction.OP_LDC_W &&
+                        currentInstruction.opcode != Instruction.OP_LDC2_W &&
+                        currentInstruction.opcode != Instruction.OP_NEW &&
+                        currentInstruction.opcode != Instruction.OP_GETSTATIC &&
+                        currentInstruction.opcode != Instruction.OP_INVOKESTATIC &&
+                        currentInstruction.opcode != Instruction.OP_INVOKEVIRTUAL &&
+                        currentInstruction.opcode != Instruction.OP_GETFIELD
+        ) {
+            System.out.println(currentInstruction.toString(offset));
+            currentTracedStack = partialEvaluator.getStackBefore(offset);
+            System.out.println(currentTracedStack);
+
+            // There is no stack value, it's coming from the variables
+            InstructionOffsetValue offsetValue;
+            if (isLoad(currentInstruction)) {
+                offsetValue = partialEvaluator.getVariablesBefore(offset).getProducerValue(((VariableInstruction) currentInstruction).variableIndex).instructionOffsetValue();
+            }
+            else {
+                offsetValue = currentTracedStack.getTopActualProducerValue(0).instructionOffsetValue();
+            }
+            for (int i = 0; i < offsetValue.instructionOffsetCount(); i++) {
+                root.children.add(traceParameterTree(partialEvaluator, codeAttribute, offsetValue.instructionOffset(i), leafNodes));
+            }
+        }
+        else {
+            // This is a leaf node, add the instruction to the list.
+            leafNodes.add(root.value);
+        }
+        return root;
+    }
+
+    public static int findFirstLambdaParameter(String descriptor) {
+        return findFirstLambdaParameter(descriptor, true);
+    }
+
+    public static int findFirstLambdaParameter(String descriptor, boolean isStatic) {
+        InternalTypeEnumeration internalTypeEnumeration = new InternalTypeEnumeration(descriptor);
+        int index = 0;
+        while (internalTypeEnumeration.hasMoreTypes()) {
+            if (internalTypeEnumeration.nextType().startsWith("Lkotlin/jvm/functions/Function")) {
+                break;
+            }
+            index ++;
+        }
+        return index + (isStatic ? 0 : 1);
+    }
+
+    /**
+     * Inline a specified method in the locations it is called in the current clazz.
+     * @param clazz The clazz in which we want to inline the targetMethod
+     * @param targetMethod The method we want to inline.
+     */
+    public static void inlineMethodInClass(Clazz clazz, Method targetMethod) {
+        clazz.methodsAccept(new AllAttributeVisitor(new MethodInliner(false, false, 20000, true, false, null) {
+            @Override
+            protected boolean shouldInline(Clazz clazz, Method method, CodeAttribute codeAttribute) {
+                return method.equals(targetMethod);
+            }
+        }));
+    }
+
+    public static void printMethodWithRange(Clazz clazz, Method method, int startOffset, int endOffset, int specialOffset) {
+        method.accept(clazz, new AllAttributeVisitor(new AllInstructionVisitor(new InstructionVisitor() {
+            @Override
+            public void visitAnyInstruction(Clazz clazz, Method method, CodeAttribute codeAttribute, int offset, Instruction instruction) {
+                String str = "   ";
+                if (offset == specialOffset) str = " * ";
+                else if (offset >= startOffset && offset < endOffset) str = " | ";
+                System.out.print(str);
+                instruction.accept(clazz, method, codeAttribute, offset, new ClassPrinter());
+            }
+        })));
+    }
+
+    public static void printMethodWithRange(Clazz clazz, Method method, int startOffset, int endOffset) {
+        printMethodWithRange(clazz, method, startOffset, endOffset, -1);
+    }
+}

--- a/base/src/main/java/proguard/optimize/inline/lambda_locator/Lambda.java
+++ b/base/src/main/java/proguard/optimize/inline/lambda_locator/Lambda.java
@@ -1,0 +1,66 @@
+package proguard.optimize.inline.lambda_locator;
+
+import proguard.classfile.Clazz;
+import proguard.classfile.Method;
+import proguard.classfile.attribute.CodeAttribute;
+import proguard.classfile.instruction.ConstantInstruction;
+
+import java.util.Objects;
+
+public final class Lambda {
+    private final Clazz clazz;
+    private final Method method;
+    private final CodeAttribute codeAttribute;
+    private final int offset;
+    private final ConstantInstruction constantInstruction;
+
+    Lambda(Clazz clazz, Method method, CodeAttribute codeAttribute, int offset, ConstantInstruction constantInstruction) {
+        this.clazz = clazz;
+        this.method = method;
+        this.codeAttribute = codeAttribute;
+        this.offset = offset;
+        this.constantInstruction = constantInstruction;
+    }
+
+    public Clazz clazz() {
+        return clazz;
+    }
+
+    public Method method() {
+        return method;
+    }
+
+    public CodeAttribute codeAttribute() {
+        return codeAttribute;
+    }
+
+    public int offset() {
+        return offset;
+    }
+
+    public ConstantInstruction constantInstruction() {
+        return constantInstruction;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) return true;
+        if (obj == null || obj.getClass() != this.getClass()) return false;
+        Lambda that = (Lambda) obj;
+        return Objects.equals(this.clazz, that.clazz) &&
+                Objects.equals(this.method, that.method) &&
+                Objects.equals(this.codeAttribute, that.codeAttribute) &&
+                this.offset == that.offset &&
+                Objects.equals(this.constantInstruction, that.constantInstruction);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(clazz, method, codeAttribute, offset, constantInstruction);
+    }
+
+    @Override
+    public String toString() {
+        return constantInstruction.toString();
+    }
+}

--- a/base/src/main/java/proguard/optimize/inline/lambda_locator/LambdaLocator.java
+++ b/base/src/main/java/proguard/optimize/inline/lambda_locator/LambdaLocator.java
@@ -1,0 +1,111 @@
+package proguard.optimize.inline.lambda_locator;
+
+import proguard.backport.LambdaExpression;
+import proguard.backport.LambdaExpressionCollector;
+import proguard.classfile.*;
+import proguard.classfile.attribute.*;
+import proguard.classfile.attribute.visitor.AllAttributeVisitor;
+import proguard.classfile.attribute.visitor.AttributeVisitor;
+import proguard.classfile.constant.*;
+import proguard.classfile.constant.visitor.ConstantVisitor;
+import proguard.classfile.instruction.ConstantInstruction;
+import proguard.classfile.instruction.Instruction;
+import proguard.classfile.instruction.visitor.AllInstructionVisitor;
+import proguard.classfile.instruction.visitor.InstructionVisitor;
+import proguard.classfile.util.ClassReferenceInitializer;
+import proguard.classfile.visitor.MemberVisitor;
+
+import java.util.*;
+
+public class LambdaLocator {
+    private final Map<Clazz, Map<Method, Set<Lambda>>> classLambdas = new HashMap<>();
+    private final List<Lambda> staticLambdas = new ArrayList<>();
+    private final Map<Integer, Lambda> staticLambdaMap = new HashMap<>();
+    private final Set<Clazz> lambdaClasses = new HashSet<>();
+
+    public LambdaLocator(ClassPool classPool, String classNameFilter) {
+        classPool.classesAccept(classNameFilter, clazz -> {
+            // Find classes that inherit from kotlin.jvm.internal.Lambda
+            clazz.superClassConstantAccept(new ConstantVisitor() {
+                @Override
+                public void visitClassConstant(Clazz clazz, ClassConstant classConstant) {
+                    clazz.constantPoolEntryAccept(classConstant.u2nameIndex, new ConstantVisitor() {
+                        @Override
+                        public void visitUtf8Constant(Clazz clazz, Utf8Constant utf8Constant) {
+                            if (utf8Constant.getString().equals("kotlin/jvm/internal/Lambda")) {
+                                System.out.println("Class " + clazz.getName() + " is a kotlin lambda class!");
+                                lambdaClasses.add(clazz);
+                            } else {
+                                System.out.println("Class " + clazz.getName() + " is not a kotlin lambda class!");
+                            }
+                        }
+                    });
+                }
+            });
+        });
+
+        // Find static lambdas
+        classPool.classesAccept(classNameFilter, clazz -> {
+
+            HashMap<Integer, LambdaExpression> h = new HashMap<>();
+            LambdaExpressionCollector lec = new LambdaExpressionCollector(h);
+            lec.visitProgramClass((ProgramClass) clazz);
+
+            clazz.methodsAccept(new MemberVisitor() {
+                @Override
+                public void visitProgramMethod(ProgramClass programClass, ProgramMethod programMethod) {
+                    programMethod.accept(programClass, new AllAttributeVisitor(new AllInstructionVisitor(new InstructionVisitor() {
+                        @Override
+                        public void visitAnyInstruction(Clazz clazz, Method method, CodeAttribute codeAttribute, int offset, Instruction instruction) {}
+
+                        @Override
+                        public void visitConstantInstruction(Clazz clazz, Method method, CodeAttribute codeAttribute, int offset, ConstantInstruction constantInstruction) {
+                            if (constantInstruction.opcode == Instruction.OP_GETSTATIC) {
+                                clazz.constantPoolEntryAccept(constantInstruction.constantIndex, new ConstantVisitor() {
+                                    @Override
+                                    public void visitFieldrefConstant(Clazz clazz, FieldrefConstant fieldrefConstant) {
+                                        clazz.constantPoolEntryAccept(fieldrefConstant.u2classIndex, new ConstantVisitor() {
+                                            @Override
+                                            public void visitClassConstant(Clazz clazz, ClassConstant classConstant) {
+                                                clazz.constantPoolEntryAccept(classConstant.u2nameIndex, new ConstantVisitor() {
+                                                    @Override
+                                                    public void visitUtf8Constant(Clazz clazz, Utf8Constant utf8Constant) {
+                                                        classPool.classAccept(utf8Constant.getString(), referencedClazz -> {
+                                                            if (lambdaClasses.contains(referencedClazz)) {
+                                                                System.out.println("Found a lambda invocation " + constantInstruction);
+
+                                                                classLambdas.putIfAbsent(clazz, new HashMap<>());
+                                                                classLambdas.get(clazz).putIfAbsent(method, new HashSet<>());
+                                                                classLambdas.get(clazz).get(method).add(new Lambda(clazz, method, codeAttribute, offset, constantInstruction));
+
+                                                                Lambda lambda = new Lambda(clazz, method, codeAttribute, offset, constantInstruction);
+                                                                staticLambdas.add(lambda);
+                                                                staticLambdaMap.put(lambda.constantInstruction().constantIndex, lambda);
+                                                            }
+                                                        });
+                                                    }
+                                                });
+                                            }
+                                        });
+                                    }
+                                });
+                            }
+                        }
+                    })));
+                }
+            });
+        });
+    }
+
+    public Map<Clazz, Map<Method, Set<Lambda>>> getLambdasByClass() {
+        return classLambdas;
+    }
+
+    public List<Lambda> getStaticLambdas() {
+        return staticLambdas;
+    }
+
+    public Map<Integer, Lambda> getStaticLambdaMap() {
+        return staticLambdaMap;
+    }
+}

--- a/base/src/main/java/proguard/optimize/inline/lambda_locator/Util.java
+++ b/base/src/main/java/proguard/optimize/inline/lambda_locator/Util.java
@@ -1,0 +1,89 @@
+package proguard.optimize.inline.lambda_locator;
+
+import proguard.classfile.visitor.ClassPrinter;
+import proguard.classfile.ClassPool;
+import proguard.classfile.ProgramClass;
+import proguard.classfile.visitor.ClassPoolFiller;
+import proguard.io.*;
+import proguard.io.util.IOUtil;
+
+import java.io.*;
+import java.nio.charset.StandardCharsets;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+import java.util.zip.ZipInputStream;
+
+public class Util {
+    /*public static ClassPool loadApk(String filename) throws IOException {
+        return IOUtil.read(
+                new File(filename),
+                false,
+                false,
+                (dataEntryReader, classVisitor) -> new NameFilteredDataEntryReader(
+                        "classes*.dex",
+                        new DexClassReader(
+                                true,
+                                classVisitor
+                        ),
+                        dataEntryReader)
+        );
+    }*/
+
+    public static ClassPool loadJar(String filename) throws IOException {
+        ClassPool classPool = new ClassPool();
+
+        DataEntrySource source =
+                new FileSource(
+                        new File(filename));
+
+        source.pumpDataEntries(
+                new JarReader(false,
+                        new ClassFilter(
+                                new ClassReader(false, false, false, false, null,
+                                        new ClassPoolFiller(classPool)))));
+        return classPool;
+    }
+
+    public static String getMainClassFromJar(String filename) throws IOException {
+        String mainClass = null;
+        ZipFile zipFile = new ZipFile(filename);
+        ZipInputStream zipInputStream = new ZipInputStream(new FileInputStream(filename), StandardCharsets.UTF_8);
+        while (true) {
+            ZipEntry entry = zipInputStream.getNextEntry();
+            if (entry == null) break;
+
+            if (entry.getName().equals("META-INF/MANIFEST.MF")) {
+                System.out.println(entry);
+                InputStream iStream = zipFile.getInputStream(entry);
+                BufferedReader reader = new BufferedReader(new InputStreamReader(iStream));
+                while (true) {
+                    String line = reader.readLine();
+                    if (line == null) break;
+
+                    if (line.startsWith("Main-Class: "))
+                        mainClass = line.substring(line.indexOf(':')+1).trim();
+                }
+            }
+        }
+        zipInputStream.close();
+        zipFile.close();
+        return mainClass;
+    }
+
+    public static void writeJar(ClassPool programClassPool, String outputJarFileName) throws IOException {
+        JarWriter jarWriter =
+                new JarWriter(
+                        new ZipWriter(
+                                new FixedFileWriter(
+                                        new File(outputJarFileName))));
+
+        programClassPool.classesAccept(
+                new DataEntryClassWriter(jarWriter));
+
+        jarWriter.close();
+    }
+
+    public static void printClass(ClassPool classPool, String className) {
+        classPool.classAccept(className, new ClassPrinter());
+    }
+}

--- a/base/src/test/kotlin/proguard/lambdaInline/AdvancedTest.kt
+++ b/base/src/test/kotlin/proguard/lambdaInline/AdvancedTest.kt
@@ -1,0 +1,283 @@
+package proguard.lambdaInline
+
+import compareOutputAndMainInstructions
+import io.kotest.core.spec.style.FreeSpec
+import proguard.testutils.KotlinSource
+
+class AdvancedTest: FreeSpec ({
+    "three lambda functions with two of same size and one different" {
+        //setup
+        val code = KotlinSource( //create java file
+            "Main.kt",
+            """
+        fun test(a: (Int) -> Int) {
+            println(a(12))
+        }
+        fun a(b: (String) -> Int) {
+            println(b("Hello World!") + 1)
+        }
+        
+        fun test1(a: (Int) -> Int, b: (String, Boolean, Int) -> Boolean, c: (Int) -> Int) {
+            println(a(3))
+            println(b("Hello", true, 0))
+            println(c(5))
+        }
+        
+        
+        fun main() {
+            var index = 0
+            while (index < 100) {
+                index += 1
+                test { a: Int -> (a * a) + 1 }
+                a { b: String ->
+                        var cnt = 0
+                        var i = 0
+                        while (i < b.length) {
+                            cnt += b[i].code
+                            i++
+                        }
+                        cnt
+                }
+                test1({ a: Int -> a * a }, { a : String, b : Boolean, c : Int -> a.uppercase(); b}, {a : Int -> a+a})
+            }
+        }
+        """
+        )
+
+        compareOutputAndMainInstructions(
+            code,
+            listOf(
+                "iconst_0",
+                "istore_0",
+                "iload_0",
+                "bipush",
+                "if_icmpge",
+                "iinc",
+                "nop",
+                "invokestatic",
+                "invokestatic",
+                "invokestatic",
+                "goto",
+                "return"
+            )
+        )
+    }
+
+    "switch case, unit lambda, multiple call to the same lambda" {
+        val code = KotlinSource( //create java file
+            "Main.kt",
+            """
+        fun test(a: (Int) -> Unit) {
+            a(1)
+            a(2)
+            a(3)
+        }
+
+        fun main() {
+            test { 
+                when(it) {
+                    1 -> println("Hello")
+                    2 -> println("World")
+                    3 -> println("!")
+                }
+            }
+        }
+        """
+        )
+
+        compareOutputAndMainInstructions(code, listOf("invokestatic", "return"))
+    }
+
+    "Casting basic types after the lambda call" {
+        val code = KotlinSource( //create java file
+            "Main.kt",
+            """
+        fun test(a: (Int) -> Int) {
+            println(a(12))
+
+            var i: Int = 1
+            var f: Float = i.toFloat()
+            println(f + 4.3)
+        }
+        
+        fun main() {
+            test { a: Int -> (a * a) + 1 }
+        }
+        """
+        )
+
+        compareOutputAndMainInstructions(code, listOf("invokestatic", "return"))
+    }
+
+    "Casting types before the lambda call" {
+        val code = KotlinSource( //create java file
+            "Main.kt",
+            """
+        fun test(a: (Int) -> Int) {
+            val a = test1(5)
+            if (a is Int) {
+                println(a + 1)
+            } else if (a is Boolean) {
+                println(a and true)
+            }
+        
+            println(a(12))
+        }
+        
+        fun test1(a:Any): Any {
+            if (a is Int) {
+                return true
+            } else if (a is Boolean) {
+                return 7
+            } else {
+                return 'a'
+            }
+        }
+        
+        fun main() {
+            test { a: Int -> (a * a) + 1 }
+        }
+        """
+        )
+
+        compareOutputAndMainInstructions(code, listOf("invokestatic", "return"))
+    }
+
+    "Casting types after the lambda call" {
+        val code = KotlinSource( //create java file
+            "Main.kt",
+            """
+        fun test(a: (Int) -> Int) {
+            println(a(12))
+
+            val a = test1(5)
+            if (a is Int) {
+                println(a + 1)
+            } else if (a is Boolean) {
+                println(a and true)
+            }
+        }
+        
+        fun test1(a:Any): Any {
+            if (a is Int) {
+                return true
+            } else if (a is Boolean) {
+                return 7
+            } else {
+                return 'a'
+            }
+        }
+        
+        fun main() {
+            test { a: Int -> (a * a) + 1 }
+        }
+        """
+        )
+
+        compareOutputAndMainInstructions(code, listOf("invokestatic", "return"))
+    }
+
+    "Casting types between lambda calls" {
+        val code = KotlinSource( //create java file
+            "Main.kt",
+            """
+        fun test(a: (Int) -> Int) {
+            println(a(12))
+
+            val a = test1(5)
+            if (a is Int) {
+                println(a + 1)
+            } else if (a is Boolean) {
+                println(a and true)
+            }
+
+            println(a(12))
+        }
+        
+        fun test1(a:Any): Any {
+            if (a is Int) {
+                return true
+            } else if (a is Boolean) {
+                return 7
+            } else {
+                return 'a'
+            }
+        }
+        
+        fun main() {
+            test { a: Int -> (a * a) + 1 }
+        }
+        """
+        )
+
+        compareOutputAndMainInstructions(code, listOf("invokestatic", "return"))
+    }
+
+    "Casting types inside lambda call" {
+        val code = KotlinSource( //create java file
+            "Main.kt",
+            """
+            fun test(a: (Any) -> Int) {
+                println(a(1))
+            }
+            
+            fun main() {
+                test { a: Any ->  if (a is Int) {
+                    println(a + 1)
+                } else if (a is Boolean) {
+                    println(a and true)
+                }; 1}
+            }
+        """
+        )
+
+        compareOutputAndMainInstructions(code, listOf("invokestatic", "return"))
+    }
+
+    "Casting types inside lambda call + other arg" {
+        val code = KotlinSource( //create java file
+            "Main.kt",
+            """
+            fun test(a: (Any, Int) -> Int) {
+                println(a(1, 2))
+            }
+            
+            fun main() {
+                test { a: Any, b: Int ->  if (a is Int) {
+                    println(a + 1)
+                } else if (a is Boolean) {
+                    println(a and true)
+                }; b}
+            }
+        """
+        )
+
+        compareOutputAndMainInstructions(code, listOf("invokestatic", "return"))
+    }
+
+    "Recursive function should not be inlined" {
+        val code = KotlinSource(
+            "Main.kt",
+        """
+        fun test(i: Int, f: (Int) -> Unit) {
+            if (i >= 0) {
+                f(i)
+                test(i - 1, f)
+            }
+        }
+        
+        fun test2(f: (Int) -> Int) {
+            println(f(2))
+        }
+        
+        fun main() {
+            test(5) { println(it * 2) }
+            test2 { it * 3}
+        }
+        """.trimIndent())
+
+        compareOutputAndMainInstructions(code, listOf("iconst_5", "getstatic", "checkcast", "invokestatic", "invokestatic", "return"), false)
+    }
+
+
+})

--- a/base/src/test/kotlin/proguard/lambdaInline/FieldInliningTest.kt
+++ b/base/src/test/kotlin/proguard/lambdaInline/FieldInliningTest.kt
@@ -1,0 +1,53 @@
+package proguard.lambdaInline
+
+import io.kotest.core.spec.style.FreeSpec
+import onlyTestRunning
+import proguard.testutils.KotlinSource
+
+class FieldInliningTest: FreeSpec ({
+    "call lambda from field in method" {
+        //setup
+        val code = KotlinSource( //create java file
+            "Main.kt",
+            """
+        class MainKtWithAField {
+            val f = { i: Int -> i + 1 }
+        }
+
+        fun test(a: (Int) -> Int) {
+            println(a(12))
+        }
+        
+        fun main() {
+            val instance = MainKtWithAField()
+            test(instance.f)
+        }
+        """
+        )
+
+        onlyTestRunning(code)
+    }
+
+    "call lambda from a non-final field in method" {
+        //setup
+        val code = KotlinSource( //create java file
+            "Main.kt",
+            """
+        class MainKtWithAField {
+            var f = { i: Int -> i + 1 }
+        }
+
+        fun test(a: (Int) -> Int) {
+            println(a(12))
+        }
+        
+        fun main() {
+            val instance = MainKtWithAField()
+            test(instance.f)
+        }
+        """
+        )
+
+        onlyTestRunning(code)
+    }
+})

--- a/base/src/test/kotlin/proguard/lambdaInline/LambdaReturnTest.kt
+++ b/base/src/test/kotlin/proguard/lambdaInline/LambdaReturnTest.kt
@@ -1,0 +1,28 @@
+package proguard.lambdaInline
+
+import io.kotest.core.spec.style.FreeSpec
+import onlyTestRunning
+import proguard.testutils.KotlinSource
+
+class LambdaReturnTest : FreeSpec({
+    "Inline a lambda which is returned from a method" {
+        val code = KotlinSource(
+            "Main.kt",
+            """
+            fun test(): (Int) -> Int {
+                return { it * 2 }
+            }
+
+            fun consumer(f: (Int) -> Int) {
+                println(f(7))
+            }
+
+            fun main() {
+                consumer(test())    
+            }
+            """
+        )
+
+        onlyTestRunning(code)
+    }
+})

--- a/base/src/test/kotlin/proguard/lambdaInline/OneLambdaInArgsTest.kt
+++ b/base/src/test/kotlin/proguard/lambdaInline/OneLambdaInArgsTest.kt
@@ -1,0 +1,691 @@
+package proguard.lambdaInline
+
+import compareOutputAndMainInstructions
+import io.kotest.core.spec.style.FreeSpec
+import onlyTestRunning
+import proguard.testutils.KotlinSource
+
+class OneLambdaInArgsTest: FreeSpec({
+    "One lambda in args, basic case with int" {
+        //setup
+        val code = KotlinSource( //create java file
+            "Main.kt",
+            """
+        fun test(a: (Int) -> Int) {
+            println(a(12))
+        }
+        
+        fun main() {
+            test { a: Int -> (a * a) + 1 }
+        }
+        """
+        )
+
+        compareOutputAndMainInstructions(code, listOf("invokestatic", "return"))
+    }
+
+    "One lambda in args, basic case with boolean" {
+        //setup
+        val code = KotlinSource( //create java file
+            "Main.kt",
+            """
+        fun test(a: (Boolean) -> Boolean) {
+            println(a(false))
+        }
+        
+        fun main() {
+            test { a: Boolean -> a and true}
+        }
+        """
+        )
+
+        compareOutputAndMainInstructions(code, listOf("invokestatic", "return"))
+    }
+
+    "One lambda in args, basic case with char" {
+        //setup
+        val code = KotlinSource( //create java file
+            "Main.kt",
+            """
+        fun test(a: (Char) -> Char) {
+            println(a('a'))
+        }
+        
+        fun main() {
+            test { a: Char -> a}
+        }
+        """
+        )
+
+        compareOutputAndMainInstructions(code, listOf("invokestatic", "return"))
+    }
+
+    "One lambda in args and instruction before lambda function calls in main" {
+        //setup
+        val code = KotlinSource( //create java file
+            "Main.kt",
+            """
+        fun test(a: (Int) -> Int) {
+            println(a(3))
+        }
+        
+        fun main() {
+            val x=1
+            println(x)
+            test { a: Int -> (a * a) + 1 }
+        }
+        """
+        )
+
+        compareOutputAndMainInstructions(
+            code,
+            listOf("iconst_1", "istore_0", "getstatic", "iload_0", "invokevirtual", "invokestatic", "return")
+        )
+    }
+
+    "One lambda in args with if" {
+        //setup
+        val code = KotlinSource( //create java file
+            "Main.kt",
+            """
+        fun test(a: (Int) -> Boolean) {
+            println(a(3))
+        }
+        
+        fun main() {
+            test { a: Int -> a == 2 }
+        }
+        """
+        )
+
+        compareOutputAndMainInstructions(code, listOf("invokestatic", "return"))
+    }
+
+    "One lambda but in a class companion object" {
+        //setup
+        val code = KotlinSource( //create java file
+            "Main.kt",
+            """
+        
+        
+        fun main() {
+            MainKtTest.test { a: Int -> a == 2 }
+        }
+
+        class MainKtTest {
+            companion object {
+                @JvmStatic
+                fun test(a: (Int) -> Boolean) {
+                    println(a(2))
+                }
+            }
+        }
+        """
+        )
+
+        compareOutputAndMainInstructions(code, listOf("getstatic", "invokevirtual", "return"))
+    }
+
+    "One lambda but in a different class" {
+        //setup
+        val code = KotlinSource( //create java file
+            "Main.kt",
+            """
+        
+        
+        fun main() {
+            val instance = MainKtTest()
+            instance.test { a: Int -> a == 2 }
+        }
+
+        class MainKtTest {
+            fun test(a: (Int) -> Boolean) {
+                println(a(2))
+            }
+        }
+        """
+        )
+
+        compareOutputAndMainInstructions(
+            code,
+            listOf("new", "dup", "invokespecial", "astore_0", "aload_0", "invokevirtual", "return")
+        )
+    }
+
+    "One lambda in a class + other arguments" {
+        //setup
+        val code = KotlinSource( //create java file
+            "Main.kt",
+            """
+        fun main() {
+            val instance = MainKtTest()
+            instance.foo { it == 2 }
+            instance.bar(2) { it * 3 }
+            instance.foo { it == 3 }
+        }
+
+        class MainKtTest {
+            fun foo(a: (Int) -> Boolean) {
+                println(a(2))
+            }
+
+            fun bar(i: Int, f: (Int) -> Int) {
+                println(f(i))
+            }
+        }
+        """
+        )
+
+        compareOutputAndMainInstructions(
+            code,
+            listOf("new", "dup", "invokespecial", "astore_0", "aload_0", "invokevirtual", "aload_0", "iconst_2", "invokevirtual", "aload_0", "invokevirtual", "return")
+        )
+    }
+
+    "One lambda in a class + other arguments + nested + private" {
+        //setup
+        val code = KotlinSource( //create java file
+            "Main.kt",
+            """
+        fun main() {
+            val instance = MainKtTest()
+            instance.foo({ it * 2 }, { it + 3 })
+            instance.bar(2) { it * 3 }
+            instance.foo({ it + 3 }, { it * 2 })
+        }
+        
+        class MainKtTest {
+            fun foo(f1: (Int) -> Int, f2: (Int) -> Int) {
+                level2(2, f2)
+                level2(3, f1)
+            }
+        
+            fun bar(i: Int, f: (Int) -> Int) {
+                level2(i, f)
+            }
+        
+            private fun level2(i: Int, f: (Int) -> Int) {
+                println(f(i))
+            }
+        }
+        """
+        )
+
+        onlyTestRunning(code)
+    }
+
+    "One lambda in a class with a call to a function in another class" {
+        //setup
+        val code = KotlinSource( //create java file
+            "Main.kt",
+            """
+        fun main() {
+            val instance = MainKtTest()
+            instance.foo { it * 2 }
+        }
+        
+        class MainKtTest {
+            val instance = MainKtTest2()
+            fun foo(f: (Int) -> Int) {
+                instance.level2(2, f)
+            }
+        }
+
+        class MainKtTest2 {
+            val offset = 5
+            fun level2(i: Int, f: (Int) -> Int) {
+                println(f(i + offset))
+            }
+        }
+        """
+        )
+
+        onlyTestRunning(code)
+    }
+
+    "One lambda in a class with a call to a function in another class that calls a function in yet another class" {
+        //setup
+        val code = KotlinSource( //create java file
+            "Main.kt",
+            """
+        fun main() {
+            val instance = MainKtTest()
+            instance.foo { it * 2 }
+        }
+        
+        class MainKtTest {
+            val instance = MainKtTest2()
+            
+            fun foo(f: (Int) -> Int) {
+                instance.foo(2, f)
+            }
+        }
+
+        class MainKtTest2 {
+            val instance = MainKtTest3()
+            val offset = 5
+            
+            fun foo(i: Int, f: (Int) -> Int) {
+                instance.foo(i + offset, f)
+            }
+        }
+
+        class MainKtTest3 {
+            val offset = 7
+            
+            fun foo(i: Int, f: (Int) -> Int) {
+                println(f(i + offset))
+            }
+        }
+        """
+        )
+
+        onlyTestRunning(code)
+    }
+
+    "One lambda but one other argument after lambda arg" {
+        val code = KotlinSource( //create java file
+            "Main.kt",
+            """
+        
+        
+        fun test(a: (Int) -> Int, b: Int) {
+            println(a(3))
+            println(b)
+        }
+        
+        fun main() {
+            test({ a: Int -> a + a }, 1)
+        }
+
+        """
+        )
+
+        compareOutputAndMainInstructions(code, listOf("iconst_1", "invokestatic", "return"))
+    }
+
+    "One lambda but one other argument before lambda arg" {
+        val code = KotlinSource( //create java file
+            "Main.kt",
+            """
+        
+        
+        fun test(b: Int, a: (Int) -> Int) {
+            println(a(3))
+            println(b)
+        }
+        
+        fun main() {
+            test(1) { a: Int -> a + a }
+        }
+
+        """
+        )
+
+        compareOutputAndMainInstructions(code, listOf("iconst_1", "invokestatic", "return"))
+    }
+
+    "One lambda but one other argument before and after lambda arg" {
+        val code = KotlinSource( //create java file
+            "Main.kt",
+            """
+        
+        
+        fun test(b: Int, a: (Int) -> Int, c: Int) {
+            println(a(3))
+            println(b)
+            println(c)
+        }
+        
+        fun main() {
+            test(1, { a: Int -> a + a }, 123)
+        }
+
+        """
+        )
+
+        compareOutputAndMainInstructions(code, listOf("iconst_1", "bipush", "invokestatic", "return"))
+    }
+    "One lambda but multiple other arguments before and after lambda arg" {
+        val code = KotlinSource( //create java file
+            "Main.kt",
+            """
+        
+        
+        fun test(e:Int, b: Int, a: (Int) -> Int, c: Int, d: Int) {
+            println(a(3))
+            println(b)
+            println(c)
+            println(d)
+            println(e)
+        }
+        
+        fun main() {
+            test(12, 1, { a: Int -> a + a }, 123, 122)
+        }
+
+        """
+        )
+
+        compareOutputAndMainInstructions(
+            code,
+            listOf("bipush", "iconst_1", "bipush", "bipush", "invokestatic", "return")
+        )
+    }
+
+    "One lambda but the lambda is consumed by a function called from the consuming method" {
+        val code = KotlinSource( //create java file
+            "Main.kt",
+            """
+        fun level1(f: (Int) -> Int) {
+            println(level2(f))
+        }
+
+        fun level2(f: (Int) -> Int): Int {
+            return f(5)
+        }
+        
+        fun main() {
+            level1 { it * 2}
+        }
+        """
+        )
+
+        onlyTestRunning(code)
+    }
+
+    "One lambda but the lambda is consumed by a function called from the consuming method LONG" {
+        val code = KotlinSource( //create java file
+            "Main.kt",
+            """
+        fun level1(b: Long, f: (Int) -> Int, a: Long) {
+            println(level2(f, 26L, 12L, 16L))
+        }
+
+        fun level2(f: (Int) -> Int, c: Long, a: Long, b: Long): Int {
+            println(a)
+            return f(5)
+        }
+        
+        fun main() {
+            level1(26L, { it * 2}, 7L) 
+        }
+        """
+        )
+
+        onlyTestRunning(code)
+    }
+
+    "One lambda but the lambda is consumed by multiple other methods from the original consuming method" {
+        val code = KotlinSource( //create java file
+            "Main.kt",
+            """
+        fun level1(f: (Int) -> Int) {
+            println(level2_1(f))
+            println(level2_2(f))
+        }
+
+        fun level2_1(f: (Int) -> Int): Int {
+            return f(5)
+        }
+
+        fun level2_2(f: (Int) -> Int): Int {
+            return f(7)
+        }
+        
+        fun main() {
+            level1 { it * 2}
+        }
+        """
+        )
+
+        onlyTestRunning(code)
+    }
+
+    "One lambda but the lambda at even more levels" {
+        val code = KotlinSource( //create java file
+            "Main.kt",
+            """
+        fun level1(f: (Int) -> Int) {
+            println(level2_1(f))
+            println(level2_2(f))
+        }
+
+        fun level2_1(f: (Int) -> Int): Int {
+            return f(5)
+        }
+
+        fun level2_2(f: (Int) -> Int): Int {
+            return level3(f)
+        }
+
+        fun level3(f: (Int) -> Int): Int {
+            return f(7)
+        }
+        
+        fun main() {
+            level1 { it * 2}
+        }
+        """
+        )
+
+        onlyTestRunning(code)
+    }
+
+    "One lambda but the lambda at even more levels + private" {
+        val code = KotlinSource( //create java file
+            "Main.kt",
+            """
+        fun level1(f: (Int) -> Int) {
+            println(level2_1(f))
+            println(level2_2(f))
+        }
+
+        fun level2_1(f: (Int) -> Int): Int {
+            return f(5)
+        }
+
+        private fun level2_2(f: (Int) -> Int): Int {
+            return level3(f)
+        }
+
+        fun level3(f: (Int) -> Int): Int {
+            return f(7)
+        }
+        
+        fun main() {
+            level1 { it * 2}
+        }
+        """
+        )
+
+        onlyTestRunning(code)
+    }
+
+    "Lambda in a variable" {
+        val code = KotlinSource(
+            "Main.kt",
+            """
+            fun level1(f: (Int) -> Int) {
+                val x = 5 * f(2)
+                println(x)
+                val renamedFunction = f
+                println(level2_2(f))
+                println(level2_1(renamedFunction))
+            }
+            
+            fun level2_1(f: (Int) -> Int): Int {
+                return f(5)
+            }
+                
+            fun level2_2(f: (Int) -> Int): Int {
+                return level3(f)
+            }
+                        
+            fun level3(f: (Int) -> Int): Int {
+                return f(7)
+            }
+            
+            
+            fun main() {
+                println("Hello there!")
+                level1 { it * 2}
+            }
+            """.trimIndent()
+        )
+
+        onlyTestRunning(code)
+    }
+
+    "Lambda in a variable more advanced" {
+        val code = KotlinSource(
+            "Main.kt",
+            """
+            // Note: The lambda x currently does not get inlined because it is not detected in the usage pattern finder
+            // but in the future if we do try inlining it, it cannot be inlined if it is used in println but that's very
+            // uncommon anyway and only used for debugging purposes.
+            fun level1(f: (Int) -> Int) {
+                var x : (Int) -> Int = { it * 2 }
+                println(x)
+                val f2 = f
+                println(level2_2(f))
+                println(level2_1(f2))
+                println(level2_1(x))
+            }
+            
+            fun level2_1(f: (Int) -> Int): Int {
+                return f(5)
+            }
+                
+            fun level2_2(f: (Int) -> Int): Int {
+                return level3(f)
+            }
+                        
+            fun level3(f: (Int) -> Int): Int {
+                return f(7)
+            }
+            
+            
+            fun main() {
+                level1 { it * 2}
+            }
+            """.trimIndent()
+        )
+
+        onlyTestRunning(code)
+    }
+
+    "Lambda in a variable multiple usages" {
+        val code = KotlinSource(
+            "Main.kt",
+            """
+            fun foo(i: Int, f: (Int) -> Int) {
+                println(f(i))
+            }
+            
+            fun main() {
+                val x : (Int) -> Int = { it * 2 }
+                foo(1, x)
+                foo(2, x)
+            }
+            """.trimIndent()
+        )
+
+        // TODO: Currently broken due to a bug in the proguard-core test utils
+        //compareOutputAndMainInstructions(code, listOf("iconst_1", "invokestatic", "iconst_2", "invokestatic", "return"))
+    }
+
+    "Lambda in a variable multiple usages with a sum of 2 functions that take lambdas" {
+        val code = KotlinSource(
+            "Main.kt",
+            """
+            fun foo(i: Int, f: (Int) -> Int): Int {
+                return f(i)
+            }
+            
+            fun main() {
+                val x : (Int) -> Int = { it * 2 }
+                val y : (Int) -> Int = { it * 2 }
+                println(foo(2, y))                
+                println(foo(1, x) + foo(2, x))
+            }
+            """.trimIndent()
+        )
+
+        compareOutputAndMainInstructions(code, listOf(
+            "iconst_2",
+            "invokestatic",
+            "istore_2",
+            "getstatic",
+            "iload_2",
+            "invokevirtual",
+            "iconst_1",
+            "invokestatic",
+            "iconst_2",
+            "invokestatic",
+            "iadd",
+            "istore_2",
+            "getstatic",
+            "iload_2",
+            "invokevirtual",
+            "return"
+        ))
+    }
+
+    "Don't inline lambda in a variable that changes depending on an if statement" {
+        val code = KotlinSource(
+            "Main.kt",
+            """
+            fun foo(i: Int, f: (Int) -> Int) {
+                println(f(i))
+            }
+            
+            fun main() {
+                var x : (Int) -> Int = { it * 2 }
+            
+                var i = 0
+                if (i * 5 == 0) {
+                    x = { it * 3 }
+                }
+            
+                foo(1, x)
+            }
+            """.trimIndent()
+        )
+
+        compareOutputAndMainInstructions(code, listOf(
+            "getstatic",
+            "checkcast",
+            "astore_0",
+            "iconst_0",
+            "istore_1",
+            "iload_1",
+            "iconst_5",
+            "imul",
+            "ifne",
+            "getstatic",
+            "checkcast",
+            "astore_0",
+            "iconst_1",
+            "aload_0",
+            "invokestatic",
+            "return"
+        ), false)
+    }
+
+    "Not using lambda return value" {
+        val code = KotlinSource( //create java file
+            "Main.kt",
+            """
+            fun test(a: (Int) -> Int) {
+                a(12)
+            }
+            
+            fun main() {
+                test { a: Int -> (a * a) + 1 }
+            }
+            """
+        )
+        compareOutputAndMainInstructions(code, listOf("invokestatic", "return"))
+    }
+})

--- a/base/src/test/kotlin/proguard/lambdaInline/TestUtil.kt
+++ b/base/src/test/kotlin/proguard/lambdaInline/TestUtil.kt
@@ -1,0 +1,419 @@
+import proguard.optimize.inline.lambda_locator.Util
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import proguard.optimize.inline.LambdaInliner
+import proguard.AppView
+import proguard.classfile.ClassPool
+import proguard.classfile.Clazz
+import proguard.classfile.Method
+import proguard.classfile.attribute.CodeAttribute
+import proguard.classfile.attribute.visitor.AllAttributeVisitor
+import proguard.classfile.constant.*
+import proguard.classfile.constant.visitor.ConstantVisitor
+import proguard.classfile.instruction.ConstantInstruction
+import proguard.classfile.instruction.Instruction
+import proguard.classfile.instruction.visitor.AllInstructionVisitor
+import proguard.classfile.instruction.visitor.InstructionVisitor
+import proguard.classfile.util.ClassReferenceInitializer
+import proguard.classfile.visitor.AllMethodVisitor
+import proguard.classfile.visitor.ClassPoolFiller
+import proguard.classfile.visitor.MultiClassVisitor
+import proguard.evaluation.BasicInvocationUnit
+import proguard.evaluation.PartialEvaluator
+import proguard.evaluation.value.TypedReferenceValueFactory
+import proguard.io.util.IOUtil
+import proguard.optimize.info.ProgramClassOptimizationInfoSetter
+import proguard.optimize.info.ProgramMemberOptimizationInfoSetter
+import proguard.optimize.peephole.LineNumberLinearizer
+import proguard.preverify.CodePreverifier
+import proguard.testutils.ClassPoolBuilder
+import proguard.testutils.PartialEvaluatorUtil
+import proguard.testutils.TestSource
+import java.util.regex.Pattern
+import kotlin.math.pow
+import kotlin.math.sqrt
+import kotlin.system.measureTimeMillis
+
+fun compareOutputAndMainInstructions(code: TestSource, correctInstructions: List<String>, checkInvokeRemoved: Boolean=true): ClassPool {
+    val mydata = System.getProperty("java.class.path")
+    val pattern = Pattern.compile(System.getProperty("user.home") + "/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib/(.*?).jar")
+    val matcher = pattern.matcher(mydata)
+    matcher.find()
+    val libraryClassPool = Util.loadJar(matcher.group(0))
+    val (classPool, _) = ClassPoolBuilder.fromSource(code)
+
+    libraryClassPool.classesAccept(ClassPoolFiller(classPool))
+    IOUtil.writeJar(classPool, "test-files/original.jar", "MainKt")
+
+    val optimizationInfoInitializer = MultiClassVisitor(
+        ProgramClassOptimizationInfoSetter(),
+        AllMethodVisitor(
+            ProgramMemberOptimizationInfoSetter()
+        )
+    )
+    classPool.classesAccept(optimizationInfoInitializer)
+
+    val appView = AppView(classPool, libraryClassPool)
+
+    appView.programClassPool.classesAccept(
+        ClassReferenceInitializer(appView.programClassPool, appView.libraryClassPool)
+    )
+
+    val inliner = LambdaInliner("Main**")
+    inliner.execute(appView)
+
+    val linearizer = LineNumberLinearizer()
+    linearizer.execute(appView)
+
+    classPool.classesAccept("Main**", AllMethodVisitor(AllAttributeVisitor(CodePreverifier(false))))
+
+    IOUtil.writeJar(classPool, "test-files/result.jar", "MainKt")
+
+    val valueFactory = TypedReferenceValueFactory()
+    val invocationUnit = BasicInvocationUnit(valueFactory)
+    val partialEvaluator = PartialEvaluator(valueFactory, invocationUnit, true)
+    //test
+    val (instructions, _) = PartialEvaluatorUtil.evaluate(
+        "MainKt",
+        "main",
+        "()V",
+        classPool,
+        partialEvaluator
+    )
+
+    val procOriginal = ProcessBuilder("java", "-jar", "test-files/original.jar")
+        .redirectOutput(ProcessBuilder.Redirect.PIPE)
+        .redirectError(ProcessBuilder.Redirect.PIPE)
+        .start()
+
+    val resultOriginal = procOriginal.waitFor()
+
+    val procGenerated = ProcessBuilder("java", "-jar", "test-files/result.jar")
+        .redirectOutput(ProcessBuilder.Redirect.PIPE)
+        .redirectError(ProcessBuilder.Redirect.PIPE)
+        .start()
+
+    val result = procGenerated.waitFor()
+
+    //clean up
+    ProcessBuilder("rm", "-f", "test-files/original.jar")
+        .redirectOutput(ProcessBuilder.Redirect.INHERIT)
+        .redirectError(ProcessBuilder.Redirect.INHERIT)
+        .start()
+        .waitFor()
+    ProcessBuilder("rm", "-f", "test-files/result.jar")
+        .redirectOutput(ProcessBuilder.Redirect.INHERIT)
+        .redirectError(ProcessBuilder.Redirect.INHERIT)
+        .start()
+        .waitFor()
+
+    val generatedErrorString = procGenerated.errorStream.bufferedReader().readText()
+    if (generatedErrorString.isNotEmpty()) {
+        println("Error output from running jar:")
+        println(generatedErrorString)
+    }
+    withClue("Exit code should be the same!") {
+        result shouldBe resultOriginal
+    }
+    procGenerated.inputStream.bufferedReader().readText() shouldBe procOriginal.inputStream.bufferedReader().readText()
+    generatedErrorString shouldBe procOriginal.errorStream.bufferedReader().readText()
+
+    withClue({ "Instructions: $instructions\nExpected instructions: $correctInstructions" }) {
+        instructions.size shouldBe correctInstructions.size
+    }
+
+    val lambdaMethods = mutableSetOf<String>("main")
+
+
+    val c: Clazz = classPool.getClass("MainKt")
+    var i = 0
+    while (i < correctInstructions.size) {
+        instructions[i].second.name shouldBe correctInstructions[i]
+
+        //find all functions called in main method
+        if (instructions[i].second.opcode == Instruction.OP_INVOKESTATIC || instructions[i].second.opcode == Instruction.OP_INVOKEVIRTUAL) {
+            c.constantPoolEntryAccept(((instructions[i].second) as ConstantInstruction).constantIndex, object: ConstantVisitor {
+                override fun visitAnyConstant(clazz: Clazz?, constant: Constant?) {}
+                override fun visitMethodrefConstant(clazz: Clazz?, methodrefConstant: MethodrefConstant?) {
+                    methodrefConstant?.nameAndTypeIndex?.let {
+                        clazz?.constantPoolEntryAccept(it, object: ConstantVisitor {
+                            override fun visitAnyConstant(clazz: Clazz?, constant: Constant?) {}
+                            override fun visitNameAndTypeConstant(clazz: Clazz?, nameAndTypeConstant: NameAndTypeConstant?) {
+                                if (nameAndTypeConstant != null) {
+                                    clazz?.constantPoolEntryAccept(nameAndTypeConstant.u2nameIndex, object: ConstantVisitor {
+                                        override fun visitAnyConstant(clazz: Clazz?, constant: Constant?) {}
+                                        override fun visitUtf8Constant(clazz: Clazz?, utf8Constant: Utf8Constant?) {
+                                            if (utf8Constant != null) {
+                                                lambdaMethods.add(utf8Constant.string)
+                                            }
+                                        }
+                                    })
+                                }
+                            }
+                        })
+                    }
+                }
+            })
+        }
+        i++
+    }
+
+    if (checkInvokeRemoved) {
+        classPool.classesAccept("MainKt", AllMethodVisitor(AllAttributeVisitor(AllInstructionVisitor(object :
+            InstructionVisitor {
+            override fun visitAnyInstruction(
+                clazz: Clazz,
+                method: Method,
+                codeAttribute: CodeAttribute,
+                offset: Int,
+                instruction: Instruction
+            ) {
+            }
+
+            override fun visitConstantInstruction(
+                clazz: Clazz,
+                method: Method,
+                codeAttribute: CodeAttribute,
+                offset: Int,
+                constantInstruction: ConstantInstruction
+            ) {
+                //only check functions that are called in main method
+                if (constantInstruction.opcode == Instruction.OP_INVOKEINTERFACE && lambdaMethods.contains(method.getName(clazz))) {
+                    clazz.constantPoolEntryAccept(constantInstruction.constantIndex, object : ConstantVisitor {
+                        override fun visitAnyConstant(clazz: Clazz, constant: Constant) {}
+
+                        override fun visitInterfaceMethodrefConstant(
+                            clazz: Clazz,
+                            interfaceMethodrefConstant: InterfaceMethodrefConstant
+                        ) {
+                            if (interfaceMethodrefConstant.referencedClass != null) {
+                                withClue("There should be no more invoke usage after inlining.") {
+                                    interfaceMethodrefConstant.referencedClass.name.startsWith("kotlin/jvm/functions/Function") shouldBe false
+                                }
+                            }
+                        }
+                    })
+                }
+            }
+        }))))
+    }
+
+    return classPool
+}
+
+fun onlyTestRunning(code: TestSource) {
+    val mydata = System.getProperty("java.class.path")
+    val pattern = Pattern.compile(System.getProperty("user.home") + "/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib/(.*?).jar")
+    val matcher = pattern.matcher(mydata)
+    matcher.find()
+    val libraryClassPool = Util.loadJar(matcher.group(0))
+    val (classPool, _) = ClassPoolBuilder.fromSource(code)
+
+    libraryClassPool.classesAccept(ClassPoolFiller(classPool))
+    IOUtil.writeJar(classPool, "test-files/original.jar", "MainKt")
+
+    val optimizationInfoInitializer = MultiClassVisitor(
+        ProgramClassOptimizationInfoSetter(),
+        AllMethodVisitor(
+            ProgramMemberOptimizationInfoSetter()
+        )
+    )
+    classPool.classesAccept(optimizationInfoInitializer)
+
+    val appView = AppView(classPool, libraryClassPool)
+
+    appView.programClassPool.classesAccept(
+        ClassReferenceInitializer(appView.programClassPool, appView.libraryClassPool)
+    )
+
+    val inliner = LambdaInliner("Main**")
+    inliner.execute(appView)
+
+    val linearizer = LineNumberLinearizer()
+    linearizer.execute(appView)
+
+    classPool.classesAccept("Main**", AllMethodVisitor(AllAttributeVisitor(CodePreverifier(false))))
+
+    IOUtil.writeJar(classPool, "test-files/result.jar", "MainKt")
+
+    val valueFactory = TypedReferenceValueFactory()
+    val invocationUnit = BasicInvocationUnit(valueFactory)
+    val partialEvaluator = PartialEvaluator(valueFactory, invocationUnit, true)
+    //test
+    val (instructions, _) = PartialEvaluatorUtil.evaluate(
+        "MainKt",
+        "main",
+        "()V",
+        classPool,
+        partialEvaluator
+    )
+
+    val procOriginal = ProcessBuilder("java", "-jar", "test-files/original.jar")
+        .redirectOutput(ProcessBuilder.Redirect.PIPE)
+        .redirectError(ProcessBuilder.Redirect.PIPE)
+        .start()
+
+    val resultOriginal = procOriginal.waitFor()
+
+    val procGenerated = ProcessBuilder("java", "-jar", "test-files/result.jar")
+        .redirectOutput(ProcessBuilder.Redirect.PIPE)
+        .redirectError(ProcessBuilder.Redirect.PIPE)
+        .start()
+
+    val result = procGenerated.waitFor()
+
+    //clean up
+    ProcessBuilder("rm", "-f", "test-files/original.jar")
+        .redirectOutput(ProcessBuilder.Redirect.INHERIT)
+        .redirectError(ProcessBuilder.Redirect.INHERIT)
+        .start()
+        .waitFor()
+    ProcessBuilder("rm", "-f", "test-files/result.jar")
+        .redirectOutput(ProcessBuilder.Redirect.INHERIT)
+        .redirectError(ProcessBuilder.Redirect.INHERIT)
+        .start()
+        .waitFor()
+
+    val generatedErrorString = procGenerated.errorStream.bufferedReader().readText()
+    if (generatedErrorString.isNotEmpty()) {
+        println("Error output from running jar:")
+        println(generatedErrorString)
+    }
+    withClue("Exit code should be the same!") {
+        result shouldBe resultOriginal
+    }
+    procGenerated.inputStream.bufferedReader().readText() shouldBe procOriginal.inputStream.bufferedReader().readText()
+    generatedErrorString shouldBe procOriginal.errorStream.bufferedReader().readText()
+}
+
+fun testPerf(code: TestSource, inlineCode: TestSource, cleanUp: Boolean): Triple<MutableList<Long>, MutableList<Long>, MutableList<Long>> {
+    val mydata = System.getProperty("java.class.path")
+    val pattern = Pattern.compile(System.getProperty("user.home") + "/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib/(.*?).jar")
+    val matcher = pattern.matcher(mydata)
+    matcher.find()
+    val libraryClassPool = Util.loadJar(matcher.group(0))
+    val (classPool, _) = ClassPoolBuilder.fromSource(code)
+    val (inlinedClassPool, _) = ClassPoolBuilder.fromSource(inlineCode)
+
+    libraryClassPool.classesAccept(ClassPoolFiller(classPool))
+    libraryClassPool.classesAccept(ClassPoolFiller(inlinedClassPool))
+    IOUtil.writeJar(classPool, "test-files/original.jar", "MainKt")
+    IOUtil.writeJar(inlinedClassPool, "test-files/originalInlined.jar", "MainKt")
+
+    val optimizationInfoInitializer = MultiClassVisitor(
+        ProgramClassOptimizationInfoSetter(),
+        AllMethodVisitor(
+            ProgramMemberOptimizationInfoSetter()
+        )
+    )
+    classPool.classesAccept(optimizationInfoInitializer)
+
+    val inliner = LambdaInliner("Main**")
+    val appView = AppView(classPool, libraryClassPool)
+    inliner.execute(appView)
+
+    val linearizer = LineNumberLinearizer()
+    linearizer.execute(appView)
+
+    classPool.classesAccept("Main**", AllMethodVisitor(AllAttributeVisitor(CodePreverifier(false))))
+
+    IOUtil.writeJar(classPool, "test-files/result.jar", "MainKt")
+
+    //test
+    val originalTimes = mutableListOf<Long>()
+    var i = 0
+    while (i < 10000) {
+        i++
+        originalTimes.add(measureTimeMillis {
+            ProcessBuilder("java", "-jar", "test-files/original.jar")
+                .redirectOutput(ProcessBuilder.Redirect.INHERIT)
+                .redirectError(ProcessBuilder.Redirect.INHERIT)
+                .start()
+                .waitFor()
+        })
+    }
+
+    val originalInlinedTimes = mutableListOf<Long>()
+    i = 0
+    while (i < 10000) {
+        i++
+        originalInlinedTimes.add(measureTimeMillis {
+            ProcessBuilder("java", "-jar", "test-files/originalInlined.jar")
+                .redirectOutput(ProcessBuilder.Redirect.INHERIT)
+                .redirectError(ProcessBuilder.Redirect.INHERIT)
+                .start()
+                .waitFor()
+        })
+    }
+
+    val generatedTimes = mutableListOf<Long>()
+    i = 0
+    while (i < 10000) {
+        i++
+        generatedTimes.add(measureTimeMillis {
+            ProcessBuilder("java", "-jar", "test-files/result.jar")
+                .redirectOutput(ProcessBuilder.Redirect.INHERIT)
+                .redirectError(ProcessBuilder.Redirect.INHERIT)
+                .start()
+                .waitFor()
+        })
+    }
+
+
+    //clean up
+    if (cleanUp) {
+        ProcessBuilder("rm", "-f", "test-files/original.jar")
+            .redirectOutput(ProcessBuilder.Redirect.INHERIT)
+            .redirectError(ProcessBuilder.Redirect.INHERIT)
+            .start()
+            .waitFor()
+        ProcessBuilder("rm", "-f", "test-files/originalInlined.jar")
+            .redirectOutput(ProcessBuilder.Redirect.INHERIT)
+            .redirectError(ProcessBuilder.Redirect.INHERIT)
+            .start()
+            .waitFor()
+        ProcessBuilder("rm", "-f", "test-files/result.jar")
+            .redirectOutput(ProcessBuilder.Redirect.INHERIT)
+            .redirectError(ProcessBuilder.Redirect.INHERIT)
+            .start()
+            .waitFor()
+    }
+
+    val originalMean = originalTimes.average()
+    val originalInlinedMean = originalInlinedTimes.average()
+    val generatedMean = generatedTimes.average()
+    println("Original code : ${originalMean}ms  (stdev = ${stdev(originalTimes)})")
+    println("Original inlined code : ${originalInlinedMean}ms  (stdev = ${stdev(originalInlinedTimes)})")
+    println("Generated code : ${generatedMean}ms  (stdev = ${stdev(generatedTimes)})")
+    if (originalMean < generatedMean) {
+        println("Generated is slower by ${generatedMean - originalMean}ms")
+    } else {
+        println("Original is slower by ${originalMean - generatedMean}ms")
+    }
+
+
+    println("ORIGINAL : ")
+    println(originalTimes)
+    println("ORIGINAL INLINED : ")
+    println(originalInlinedTimes)
+    println("GENERATED : ")
+    println(generatedTimes)
+    return Triple(originalTimes, originalInlinedTimes, generatedTimes)
+}
+
+fun stdev(numArray: MutableList<Long>): Double {
+    var sum = 0.0
+    var standardDeviation = 0.0
+
+    for (num in numArray) {
+        sum += num
+    }
+
+    val mean = sum / numArray.size
+
+    for (num in numArray) {
+        standardDeviation += (num - mean).pow(2.0)
+    }
+
+    return sqrt(standardDeviation / numArray.size)
+}

--- a/base/src/test/kotlin/proguard/lambdaInline/ThreeLambdasInArgsTest.kt
+++ b/base/src/test/kotlin/proguard/lambdaInline/ThreeLambdasInArgsTest.kt
@@ -1,0 +1,105 @@
+package proguard.lambdaInline
+
+import compareOutputAndMainInstructions
+import io.kotest.core.spec.style.FreeSpec
+import proguard.testutils.KotlinSource
+
+class ThreeLambdasInArgsTest: FreeSpec({
+    "Three lambda in args, basic case" {
+        //setup
+        val code = KotlinSource( //create java file
+            "Main.kt",
+            """
+        fun test(a: (Int) -> Int, b: (Int, Int) -> Int, c: (String, Boolean, Int) -> Boolean) {
+            println(a(3))
+            println(b(5,7))
+            println(c("Hello", true, 0))
+        }
+        
+        fun main() {
+            test({ a: Int -> a * a }, {a : Int, b : Int -> a+b}, { a : String, b : Boolean, c : Int -> println(a); b })
+        }
+        """
+        )
+        compareOutputAndMainInstructions(code, listOf("invokestatic", "return"))
+    }
+
+    "Three lambdas in args and instruction before lambda function calls in main" {
+        //setup
+        val code = KotlinSource( //create java file
+            "Main.kt",
+            """
+        fun test(a: (Int) -> Int, b: (Int, Int) -> Int, c: (String, Boolean, Int) -> Boolean) {
+            println(a(3))
+            println(b(5,7))
+            println(c("Hello", true, 0))
+        }
+        
+        fun main() {
+            val x = 1
+            val y = 5
+            println(x + y)
+            test({ a: Int -> a * a }, {a : Int, b : Int -> a+b}, { a : String, b : Boolean, c : Int -> println(a); b})
+        }
+        """
+        )
+
+        compareOutputAndMainInstructions(
+            code,
+            listOf(
+                "iconst_1",
+                "istore_0",
+                "iconst_5",
+                "istore_1",
+                "iload_0",
+                "iload_1",
+                "iadd",
+                "istore_2",
+                "getstatic",
+                "iload_2",
+                "invokevirtual",
+                "invokestatic",
+                "return"
+            )
+        )
+    }
+    "Three lambdas in args and two are the same types" {
+        //setup
+        val code = KotlinSource( //create java file
+            "Main.kt",
+            """
+        fun test(a: (Int) -> Int, b: (Int) -> Int, c: (String, Boolean, Int) -> Boolean) {
+            println(a(3))
+            println(b(5))
+            println(c("Hello", true, 0))
+        }
+        
+        fun main() {
+            test({ a: Int -> a * a }, {a : Int -> a+a}, { a : String, b : Boolean, c : Int -> println(a); b})
+        }
+        """
+        )
+
+        compareOutputAndMainInstructions(code, listOf("invokestatic", "return"))
+    }
+
+    "Three lambdas in args and two are the same types shuffled" {
+        //setup
+        val code = KotlinSource( //create java file
+            "Main.kt",
+            """
+        fun test(a: (Int) -> Int, b: (String, Boolean, Int) -> Boolean, c: (Int) -> Int) {
+            println(a(3))
+            println(b("Hello", true, 0))
+            println(c(5))
+        }
+        
+        fun main() {
+            test({ a: Int -> a * a }, { a : String, b : Boolean, c : Int -> println(a); b}, {a : Int -> a+a})
+        }
+        """
+        )
+
+        compareOutputAndMainInstructions(code, listOf("invokestatic", "return"))
+    }
+})

--- a/base/src/test/kotlin/proguard/lambdaInline/TwoLambdasInArgsTest.kt
+++ b/base/src/test/kotlin/proguard/lambdaInline/TwoLambdasInArgsTest.kt
@@ -1,0 +1,171 @@
+package proguard.lambdaInline
+
+import compareOutputAndMainInstructions
+import io.kotest.core.spec.style.FreeSpec
+import onlyTestRunning
+import proguard.testutils.KotlinSource
+
+class TwoLambdasInArgsTest: FreeSpec({
+    "Two lambda in args, basic case" {
+        //setup
+        val code = KotlinSource( //create java file
+            "Main.kt",
+            """
+        fun test(a: (Int) -> Int, b: (Int, Int) -> Int) {
+            println(a(3))
+            println(b(5,7))
+        }
+        
+        fun main() {
+            test({ a: Int -> a * a }, {a : Int, b : Int -> a+b})
+        }
+        """
+        )
+
+        compareOutputAndMainInstructions(code, listOf("invokestatic", "return"))
+    }
+
+    "Two lambdas in args and instruction before lambda function calls in main" {
+        //setup
+        val code = KotlinSource( //create java file
+            "Main.kt",
+            """
+        fun test(a: (Int) -> Int, b: (Int, Int) -> Int) {
+            println(a(3))
+            println(b(5,7))
+        }
+        
+        fun main() {
+            val x=1
+            println(x)
+            test({ a: Int -> a * a }, {a : Int, b : Int -> a+b})
+}
+        """
+        )
+
+        compareOutputAndMainInstructions(
+            code,
+            listOf("iconst_1", "istore_0", "getstatic", "iload_0", "invokevirtual", "invokestatic", "return")
+        )
+    }
+
+    "Twice the same lambda types in args" {
+        //setup
+        val code = KotlinSource( //create java file
+            "Main.kt",
+            """
+        fun test(a: (Int) -> Int, b: (Int) -> Int) {
+            println(a(3))
+            println(b(5))
+            println((a(12) - b(15)))
+        }
+        
+        fun main() {
+            test({ a: Int -> a * a }, {a : Int -> a+a})
+        }
+        """
+        )
+
+        compareOutputAndMainInstructions(code, listOf("invokestatic", "return"))
+    }
+
+    "Twice the same lambda types in args + one lambda with one arg" {
+        //setup
+        val code = KotlinSource( //create java file
+            "Main.kt",
+            """
+        fun test(a: (Int) -> Int, b: (Int) -> Int) {
+            println(a(3))
+            println(b(5))
+            println((a(12) - b(15)))
+        }
+
+        fun test(f: (Int) -> Int) {
+            println(f(3))
+        }
+        
+        fun main() {
+            test {it * 2}
+        
+            test({ a: Int -> a * a }, {a : Int -> a + a})
+        }
+        """
+        )
+
+        compareOutputAndMainInstructions(code, listOf("invokestatic", "invokestatic", "return"))
+    }
+
+    "Two lambdas but multiple other arguments before and after lambda arg" {
+        val code = KotlinSource( //create java file
+            "Main.kt",
+            """
+        
+        
+        fun test(e:Int, b: Int, a: (Int) -> Int, c: Int, f: (Int) -> Int, d: Int) {
+            println(a(3))
+            println(b)
+            println(c)
+            println(d)
+            println(e)
+            println(f(3))
+        }
+
+        fun main() {
+            test(12, 1, { a: Int -> a + a }, 123, { a: Int -> a * a }, 122)
+        }
+        """
+        )
+
+        compareOutputAndMainInstructions(
+            code,
+            listOf("bipush", "iconst_1", "bipush", "bipush", "invokestatic", "return")
+        )
+    }
+
+
+    "Twice the same lambda types in args multiple levels" {
+        //setup
+        val code = KotlinSource( //create java file
+            "Main.kt",
+            """
+        fun level1(a: (Int) -> Int, b: (Int) -> Int) {
+            level2(b)
+            level2(a)
+        }
+
+        fun level2(f: (Int) -> Int) {
+            println(f(3))
+        }
+        
+        fun main() {
+            level1({ a -> a * a }, {a -> a + a})
+        }
+        """
+        )
+
+        onlyTestRunning(code)
+    }
+
+    "Twice the same lambda types in args multiple levels with one non lambda before the lambdas" {
+        //setup
+        val code = KotlinSource( //create java file
+            "Main.kt",
+            """
+        fun level1(i1: Int, a: (Int) -> Int, b: (Int) -> Int) {
+            level2(b)
+            level2(a)
+        }
+
+        fun level2(f: (Int) -> Int) {
+            println(f(3))
+        }
+        
+        fun main() {
+            level1(7, { a -> a * a }, {a -> 26})
+        }
+        """
+        )
+
+        onlyTestRunning(code)
+    }
+})

--- a/base/src/test/kotlin/proguard/lambdaInline/TypeTest.kt
+++ b/base/src/test/kotlin/proguard/lambdaInline/TypeTest.kt
@@ -1,0 +1,315 @@
+package proguard.lambdaInline
+
+import compareOutputAndMainInstructions
+import io.kotest.core.spec.style.FreeSpec
+import proguard.testutils.KotlinSource
+
+class TypeTest: FreeSpec ({
+    "Byte" {
+        val code = KotlinSource( //create java file
+            "Main.kt",
+            """
+            fun test(a: (Byte) -> Byte) {
+                println(a(12))
+            }
+            
+            fun main() {
+                test { a: Byte -> (a + 1).toByte() }
+            }
+            """
+        )
+        compareOutputAndMainInstructions(code, listOf("invokestatic", "return"))
+    }
+
+    "Short" {
+        val code = KotlinSource( //create java file
+            "Main.kt",
+            """
+            fun test(a: (Short) ->Short) {
+                println(a(12))
+            }
+            
+            fun main() {
+                test { a: Short -> (a + 1).toShort() }
+            }
+            """
+        )
+        compareOutputAndMainInstructions(code, listOf("invokestatic", "return"))
+    }
+
+    "Int" {
+        val code = KotlinSource( //create java file
+            "Main.kt",
+            """
+            fun test(a: (Int) -> Int) {
+                println(a(12))
+            }
+            
+            fun main() {
+                test { a: Int -> (a * a) + 1 }
+            }
+            """
+        )
+        compareOutputAndMainInstructions(code, listOf("invokestatic", "return"))
+    }
+
+
+    "Long" {
+        val code = KotlinSource( //create java file
+            "Main.kt",
+            """
+            fun test(a: (Long) -> Long) {
+                println(a(12L))
+            }
+            
+            fun main() {
+                test { a: Long -> a + 2L }
+            }
+            """
+        )
+        compareOutputAndMainInstructions(code, listOf("invokestatic", "return"))
+    }
+
+    "Long in consumingMethod args" {
+        val code = KotlinSource( //create java file
+            "Main.kt",
+            """
+            fun test(c:Long, a: (Long) -> Long, b: Long) {
+                println(b)
+                println(c)
+                println(a(b))
+            }
+            
+            fun main() {
+                test(42L, { a: Long -> a + 2L }, 12L)
+            }
+            """
+        )
+        compareOutputAndMainInstructions(code, listOf("ldc2_w", "ldc2_w", "invokestatic", "return"))
+    }
+
+    "Float" {
+        val code = KotlinSource( //create java file
+            "Main.kt",
+            """
+            fun test(a: (Float) -> Float) {
+                println(a(12f))
+            }
+            
+            fun main() {
+                test { a: Float -> a + 2.3f }
+            }
+            """
+        )
+        compareOutputAndMainInstructions(code, listOf("invokestatic", "return"))
+    }
+
+    "Double" {
+        val code = KotlinSource( //create java file
+            "Main.kt",
+            """
+            fun test(a: (Double) -> Double) {
+                println(a(3.14))
+            }
+            
+            fun main() {
+                test { a: Double -> a + 2.3 }
+            }
+            """
+        )
+        compareOutputAndMainInstructions(code, listOf("invokestatic", "return"))
+    }
+
+    "Boolean" {
+        val code = KotlinSource( //create java file
+            "Main.kt",
+            """
+            fun test(a: (Boolean) -> Boolean) {
+                println(a(true))
+            }
+            
+            fun main() {
+                test { a: Boolean -> a and true }
+            }
+            """
+        )
+        compareOutputAndMainInstructions(code, listOf("invokestatic", "return"))
+    }
+
+    "Char" {
+        val code = KotlinSource( //create java file
+            "Main.kt",
+            """
+            fun test(a: (Char) -> Char) {
+                println(a('j'))
+            }
+            
+            fun main() {
+                test { a: Char -> a.uppercaseChar() }
+            }
+            """
+        )
+        compareOutputAndMainInstructions(code, listOf("invokestatic", "return"))
+    }
+
+    "String" {
+        val code = KotlinSource( //create java file
+            "Main.kt",
+            """
+            fun test(a: (String) -> String) {
+                println(a("Hello World!"))
+            }
+            
+            fun main() {
+                test { a: String -> a + " And you!" }
+            }
+            """
+        )
+        compareOutputAndMainInstructions(code, listOf("invokestatic", "return"))
+    }
+
+    "ByteArray" {
+        val code = KotlinSource( //create java file
+            "Main.kt",
+            """
+            fun test(a: (ByteArray) -> ByteArray) {
+                println(a(byteArrayOf(1, 5, 3)).contentToString())
+            }
+            
+            fun main() {
+                test { a: ByteArray -> byteArrayOf(1) + a }
+            }
+            """
+        )
+        compareOutputAndMainInstructions(code, listOf("invokestatic", "return"))
+    }
+
+    "ShortArray" {
+        val code = KotlinSource( //create java file
+            "Main.kt",
+            """
+            fun test(a: (ShortArray) -> ShortArray) {
+                println(a(shortArrayOf(1, 5, 3)).contentToString())
+            }
+            
+            fun main() {
+                test { a: ShortArray -> shortArrayOf(1) + a }
+            }
+            """
+        )
+        compareOutputAndMainInstructions(code, listOf("invokestatic", "return"))
+    }
+
+    "IntArray" {
+        val code = KotlinSource( //create java file
+            "Main.kt",
+            """
+            fun test(a: (IntArray) -> IntArray) {
+                println(a(intArrayOf(1, 5, 3)).contentToString())
+            }
+            
+            fun main() {
+                test { a: IntArray -> intArrayOf(1) + a }
+            }
+            """
+        )
+        compareOutputAndMainInstructions(code, listOf("invokestatic", "return"))
+    }
+
+    "LongArray" {
+        val code = KotlinSource( //create java file
+            "Main.kt",
+            """
+            fun test(a: (LongArray) -> LongArray) {
+                println(a(longArrayOf(1, 5, 3)).contentToString())
+            }
+            
+            fun main() {
+                test { a: LongArray -> longArrayOf(1) + a }
+            }
+            """
+        )
+        compareOutputAndMainInstructions(code, listOf("invokestatic", "return"))
+    }
+
+    "FloatArray" {
+        val code = KotlinSource( //create java file
+            "Main.kt",
+            """
+            fun test(a: (FloatArray) -> FloatArray) {
+                println(a(floatArrayOf(1.12f, 5f, 3.89f)).contentToString())
+            }
+            
+            fun main() {
+                test { a: FloatArray -> floatArrayOf(1.2f) + a }
+            }
+            """
+        )
+        compareOutputAndMainInstructions(code, listOf("invokestatic", "return"))
+    }
+
+    "DoubleArray" {
+        val code = KotlinSource( //create java file
+            "Main.kt",
+            """
+            fun test(a: (DoubleArray) -> DoubleArray) {
+                println(a(doubleArrayOf(1.12, 5.0, 3.89)).contentToString())
+            }
+            
+            fun main() {
+                test { a: DoubleArray -> doubleArrayOf(1.2) + a }
+            }
+            """
+        )
+        compareOutputAndMainInstructions(code, listOf("invokestatic", "return"))
+    }
+
+    "CharArray" {
+        val code = KotlinSource( //create java file
+            "Main.kt",
+            """
+            fun test(a: (CharArray) -> CharArray) {
+                println(a(charArrayOf('a', 't', '%')).contentToString())
+            }
+            
+            fun main() {
+                test { a: CharArray -> charArrayOf('5') + a }
+            }
+            """
+        )
+        compareOutputAndMainInstructions(code, listOf("invokestatic", "return"))
+    }
+
+    "StringArray" {
+        val code = KotlinSource( //create java file
+            "Main.kt",
+            """
+            fun test(a: (Array<String>) -> Array<String>) {
+                println(a(arrayOf("raspberry", "pear", "banana")).contentToString())
+            }
+            
+            fun main() {
+                test { a: Array<String> -> arrayOf("apple") + a }
+            }
+            """
+        )
+        compareOutputAndMainInstructions(code, listOf("invokestatic", "return"))
+    }
+
+    "Any" {
+        val code = KotlinSource( //create java file
+            "Main.kt",
+            """
+            fun test(a: (Any) -> Any) {
+                println(a(arrayOf("raspberry", "pear", "banana"))::class)
+            }
+            
+            fun main() {
+                test { a: Any -> a }
+            }
+            """
+        )
+        compareOutputAndMainInstructions(code, listOf("invokestatic", "return"))
+    }
+
+})

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 proguardVersion = 7.3.3
 
 # The version of ProGuardCORE that sub-projects are built with
-proguardCoreVersion = 9.0.9
+proguardCoreVersion = 9.0.10
 gsonVersion = 2.9.0
 kotlinVersion = 1.7.20
 target = 1.8


### PR DESCRIPTION
Added lambda inlining for Kotlin lambdas passed directly as an argument or stored in a variable then passed as an argument. It currently cannot inline lambdas that are passed to a method and then used as an argument to a method called from the first method. We currently do not inline from final fields, nor from lambdas returned from methods. So we just handle the most basic cases for now.