### PR TITLE
Fix equals to prevent null values

### DIFF
--- a/retrace/src/proguard/retrace/FrameRemapper.java
+++ b/retrace/src/proguard/retrace/FrameRemapper.java
@@ -116,7 +116,7 @@ public class FrameRemapper implements MappingProcessor
                     if (fieldInfo.matches(originalType))
                     {
                         originalFieldFrames.add(new FrameInfo(fieldInfo.originalClassName,
-                                                              obfuscatedFrame.getSourceFile().equals("Unknown Source") ?
+                                                              "Unknown Source".equals(obfuscatedFrame.getSourceFile()) ?
                                                                       "Unknown Source" :
                                                                       sourceFileName(fieldInfo.originalClassName),
                                                               obfuscatedFrame.getLineNumber(),
@@ -186,7 +186,7 @@ public class FrameRemapper implements MappingProcessor
                         }
 
                         originalMethodFrames.add(new FrameInfo(methodInfo.originalClassName,
-                                                               obfuscatedFrame.getSourceFile().equals("Unknown Source") ?
+                                                               "Unknown Source".equals(obfuscatedFrame.getSourceFile()) ?
                                                                        "Unknown Source" :
                                                                        sourceFileName(methodInfo.originalClassName),
                                                                lineNumber,


### PR DESCRIPTION
Switch frame.getSourceFile().equals(String) around to test String against source file value instead of otherway around to prevent  failures when the value is null.

This fixed this issue https://github.com/Guardsquare/proguard/issues/351