### PR TITLE
chore: add .kotlin from Kotlin 2.0.0 in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ build
 local.properties
 /lib/
 docs/html
+.kotlin


### PR DESCRIPTION
It looks like this project has been updated to support and use Kotlin 2.0.0 in 7.5.0 with 
- #404 

 but when building the project you will get this message in the IDE:

![image](https://github.com/Guardsquare/proguard/assets/73608287/04210508-ef45-4275-a502-d4dd85f2994f)

Also using `git add .` will add `.kotlin` will add the file to the staging area which might cause it to be accidently committed, it will be generated when building the project using `./gradlew build` or any other way

see this for more info: https://kotlinlang.org/docs/whatsnew20.html#new-directory-for-kotlin-data-in-gradle-projects

### Not related to the PR

There is a warning when building the project:

```console
The Kotlin Gradle plugin was loaded multiple times in different subprojects, which is not supported and may break the build. 
This might happen in subprojects that apply the Kotlin plugins with the Gradle 'plugins { ... }' DSL if they specify explicit versions, even if the versions are equal.
Please add the Kotlin plugin to the common parent project or the root project, then remove the versions in the subprojects.
If the parent project does not need the plugin, add 'apply false' to the plugin line.
See: https://docs.gradle.org/current/userguide/plugins.html#sec:subprojects_plugins_dsl
The Kotlin plugin was loaded in the following projects: ':base', ':gradle'
```

which can be fixed by `apply false` for the Kotlin plugin in the root project and apply them in the modules where it's needed