### PR TITLE
Separate Multiple Frames With a Newline

### DIFF
--- a/retrace/src/proguard/retrace/ReTrace.java
+++ b/retrace/src/proguard/retrace/ReTrace.java
@@ -226,6 +226,9 @@ public class ReTrace
                     }
 
                     result.append(trimmedLine);
+                    if (retracedFrames.hasNext()) {
+                        result.append(System.lineSeparator());
+                    }
                 }
 
                 previousLine = retracedLine;


### PR DESCRIPTION
When an obfuscated frame resolves to multiple clear frames, separate them with a newline.

See https://github.com/Guardsquare/proguard/issues/432
