### PR TITLE
Exclude annotation members from aggressive overloading

### DIFF
--- a/base/src/main/java/proguard/obfuscate/MemberNameCollector.java
+++ b/base/src/main/java/proguard/obfuscate/MemberNameCollector.java
@@ -78,7 +78,7 @@ implements   MemberVisitor
             String descriptor = member.getDescriptor(clazz);
 
             // Check whether we're allowed to do aggressive overloading
-            if (!allowAggressiveOverloading)
+            if (!allowAggressiveOverloading || clazz.extendsOrImplements("java/lang/annotation/Annotation"))
             {
                 // Trim the return argument from the descriptor if not.
                 // Works for fields and methods alike.

--- a/base/src/main/java/proguard/obfuscate/MemberNameConflictFixer.java
+++ b/base/src/main/java/proguard/obfuscate/MemberNameConflictFixer.java
@@ -109,7 +109,7 @@ public class MemberNameConflictFixer implements MemberVisitor
         String descriptor = member.getDescriptor(clazz);
 
         // Check whether we're allowed to overload aggressively.
-        if (!allowAggressiveOverloading)
+        if (!allowAggressiveOverloading || clazz.extendsOrImplements("java/lang/annotation/Annotation"))
         {
             // Trim the return argument from the descriptor if not.
             // Works for fields and methods alike.

--- a/base/src/main/java/proguard/obfuscate/MemberObfuscator.java
+++ b/base/src/main/java/proguard/obfuscate/MemberObfuscator.java
@@ -81,7 +81,7 @@ implements   MemberVisitor
         String descriptor = member.getDescriptor(clazz);
 
         // Check whether we're allowed to overload aggressively.
-        if (!allowAggressiveOverloading)
+        if (!allowAggressiveOverloading || clazz.extendsOrImplements("java/lang/annotation/Annotation"))
         {
             // Trim the return argument from the descriptor if not.
             // Works for fields and methods alike.


### PR DESCRIPTION
Aggressive overloading class members of annotations can cause errors like this: ```
Caused by: java.lang.annotation.AnnotationFormatError: java.lang.IllegalArgumentException: methods with same signature a() but incompatible return types: boolean and others
	at java.base/sun.reflect.annotation.AnnotationParser.parseAnnotations(AnnotationParser.java:78)
	at java.base/java.lang.reflect.Field.declaredAnnotations(Field.java:1211)
	at java.base/java.lang.reflect.Field.declaredAnnotations(Field.java:1209)
	at java.base/java.lang.reflect.Field.getAnnotation(Field.java:1176)
```

This PR excludes annotation class members from aggressive overloading, allowing them to still be obfuscated and for the rest of a project to have aggressive overloading enabled.