### PR TITLE
Update ProGuardCORE version for Java 24 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.guardsquare:proguard-gradle:7.6.1'
+        classpath 'com.guardsquare:proguard-gradle:7.7.0'
     }
 }
 ```
@@ -192,7 +192,7 @@ guide](CONTRIBUTING.md) if you would like to contribute.
 
 ## 📝 License
 
-Copyright (c) 2002-2023 [Guardsquare NV](https://www.guardsquare.com/).
+Copyright (c) 2002-2025 [Guardsquare NV](https://www.guardsquare.com/).
 ProGuard is released under the [GNU General Public License, version
 2](LICENSE), with [exceptions granted to a number of
 projects](docs/md/manual/license/gplexception.md).

--- a/docs/md/manual/home.md
+++ b/docs/md/manual/home.md
@@ -1,4 +1,4 @@
-Welcome to the manual for **ProGuard** version 7.6.2 ([what's new?](releasenotes.md)).
+Welcome to the manual for **ProGuard** version 7.7 ([what's new?](releasenotes.md)).
 
 ProGuard is an open-sourced Java class file shrinker, optimizer, obfuscator, and
 preverifier. As a result, ProGuard processed applications and libraries are smaller and faster.

--- a/docs/md/manual/releasenotes.md
+++ b/docs/md/manual/releasenotes.md
@@ -1,5 +1,8 @@
+## Version 7.7
 
-## Version 7.6.2
+### Java support
+
+- Add support for Java 24. (#458)
 
 ### Bugfixes
 

--- a/docs/md/manual/releasenotes.md
+++ b/docs/md/manual/releasenotes.md
@@ -7,6 +7,7 @@
 ### Bugfixes
 
 - Prevent `IllegalArgumentException` when strings longer than 65535 bytes are present in the application (#267).
+- Prevent `StackOverflowException` when processing a pattern match switch (#444).
 
 ### Improved
 

--- a/examples/application-kotlin/build.gradle
+++ b/examples/application-kotlin/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.guardsquare:proguard-gradle:7.6.1'
+        classpath 'com.guardsquare:proguard-gradle:7.7.0'
     }
 }
 

--- a/examples/application/build.gradle
+++ b/examples/application/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.guardsquare:proguard-gradle:7.6.1'
+        classpath 'com.guardsquare:proguard-gradle:7.7.0'
     }
 }
 

--- a/examples/gradle-kotlin-dsl/build.gradle.kts
+++ b/examples/gradle-kotlin-dsl/build.gradle.kts
@@ -5,7 +5,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath("com.guardsquare:proguard-gradle:7.6.1")
+        classpath("com.guardsquare:proguard-gradle:7.7.0")
     }
 }
 

--- a/examples/spring-boot/build.gradle
+++ b/examples/spring-boot/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.guardsquare:proguard-gradle:7.6.1'
+        classpath 'com.guardsquare:proguard-gradle:7.7.0'
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
-proguardVersion = 7.6.2
+proguardVersion = 7.7.0
 
 # The version of ProGuardCORE that sub-projects are built with
-proguardCoreVersion = 9.1.7
+proguardCoreVersion = 9.1.10
 gsonVersion = 2.11.0
 kotlinVersion = 2.1.0
 target = 1.8


### PR DESCRIPTION
Java 24 support (#458). There does not appear to be any changes to bytecode/class file format that require any further changes beyond the version bump in ProGuard(CORE). See https://openjdk.org/projects/jdk/24/

Requires publishing ProGuardCORE 9.1.10 to Maven Central with the Java 24 version bump before this one can be merged (https://github.com/Guardsquare/proguard-core/pull/136)

I've bumped the version number to 7.7.0 since a minor bump is normally done with a new Java/Kotlin version support.