### PR TITLE
fix NullPointerException for Kotlin typealias of typealias of lambda

### DIFF
--- a/base/src/main/java/proguard/shrink/ClassUsageMarker.java
+++ b/base/src/main/java/proguard/shrink/ClassUsageMarker.java
@@ -2068,7 +2068,10 @@ implements   ClassVisitor,
                 else if (kotlinTypeMetadata.aliasName != null && !isUsed(kotlinTypeMetadata.referencedTypeAlias))
                 {
                     markAsUsed(kotlinTypeMetadata.referencedTypeAlias);
-                    kotlinTypeMetadata.referencedTypeAlias.accept(null, null, this);
+                    kotlinTypeMetadata.referencedTypeAlias.accept(
+                            kotlinTypeMetadata.referencedTypeAlias.referencedDeclarationContainer.ownerReferencedClass,
+                            kotlinTypeMetadata.referencedTypeAlias.referencedDeclarationContainer,
+                            this);
                 }
 
                 markAsUsed(kotlinTypeMetadata.typeArguments);


### PR DESCRIPTION
fix  #309 
If the kotlin version is lower than v2.0.0, such as 1.9.0, the following code can reproduce the problem
```kotlin 
package com.hello

import androidx.annotation.Keep

typealias typeOne = () -> Unit
typealias typeTwo = typeOne

class KotlinQQ {
    @Keep
    fun testWorld(world: typeTwo) {
    }
}
```