### PR TITLE
Typo in gradle task example

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.guardsquare:proguard-gradle:7.7.1'
+        classpath 'com.guardsquare:proguard-gradle:7.7.0'
     }
 }
 ```


### PR DESCRIPTION
This may be useless but it was giving an error with 7.7.1 but works fine with 7.7.0