### PR TITLE
POC: Use `jrt:/` file system as fallback for missing jmods

### DIFF
--- a/base/src/main/java/proguard/JrtDataEntry.java
+++ b/base/src/main/java/proguard/JrtDataEntry.java
@@ -1,0 +1,72 @@
+package proguard;
+
+import proguard.io.DataEntry;
+
+import java.io.BufferedInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/**
+ * Data entry created by {@link JrtDataEntrySource}.
+ */
+public class JrtDataEntry implements DataEntry {
+    private final Path jrtPath;
+    private final String name;
+    private final long size;
+
+    private InputStream inputStream = null;
+
+    public JrtDataEntry(Path jrtPath, String name, long size) {
+        this.jrtPath = jrtPath;
+        this.name = name;
+        this.size = size;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public String getOriginalName() {
+        return getName();
+    }
+
+    @Override
+    public long getSize() {
+        return size;
+    }
+
+    @Override
+    public boolean isDirectory() {
+        return false;
+    }
+
+    @Override
+    public InputStream getInputStream() throws IOException {
+        if (inputStream == null) {
+            inputStream = new BufferedInputStream(Files.newInputStream(jrtPath));
+        }
+        return inputStream;
+    }
+
+    @Override
+    public void closeInputStream() throws IOException {
+        if (inputStream != null) {
+            inputStream.close();
+            inputStream = null;
+        }
+    }
+
+    @Override
+    public DataEntry getParent() {
+        return null;
+    }
+
+    @Override
+    public String toString() {
+        return "jrt:/" + jrtPath;
+    }
+}

--- a/base/src/main/java/proguard/JrtDataEntrySource.java
+++ b/base/src/main/java/proguard/JrtDataEntrySource.java
@@ -1,0 +1,101 @@
+package proguard;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import proguard.io.DataEntryReader;
+import proguard.io.DataEntrySource;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.file.*;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.Collections;
+import java.util.stream.Stream;
+
+/**
+ * Data entry source which reads JDK classes using the {@code jrt:/} file system.
+ *
+ * @see <a href="https://openjdk.org/jeps/220">JEP 220</a>
+ */
+public class JrtDataEntrySource implements DataEntrySource, Closeable {
+    @Nullable
+    private final String moduleName;
+    private final FileSystem jrtFileSystem;
+    private final URLClassLoader fallbackClassLoader;
+
+    /**
+     * @param javaHome path to JAVA_HOME whose classes should be read
+     * @param moduleName name of the module whose classes should be read; {@code null} to read the classes of
+     *                   all modules
+     */
+    public JrtDataEntrySource(Path javaHome, @Nullable String moduleName) {
+        this.moduleName = moduleName;
+
+        Path jrtFsJarPath = getJrtFsJarPath(javaHome);
+        if (!Files.isRegularFile(jrtFsJarPath)) {
+            throw new IllegalArgumentException("Missing file in JAVA_HOME: " + jrtFsJarPath);
+        }
+        try {
+            // This class loader is used as fallback when the current JDK is JDK 8 and does not itself have the
+            // provider for the `jrt:/` file system
+            fallbackClassLoader = new URLClassLoader(new URL[] {jrtFsJarPath.toUri().toURL()});
+        } catch (MalformedURLException e) {
+            throw new RuntimeException("Failed converting file path to URL", e);
+        }
+
+        try {
+            jrtFileSystem = FileSystems.newFileSystem(URI.create("jrt:/"), Collections.singletonMap("java.home", javaHome.toString()), fallbackClassLoader);
+        } catch (Exception e) {
+            // Should not happen normally
+            throw new RuntimeException("Failed creating jrt:/ file system for JAVA_HOME " + javaHome);
+        }
+    }
+
+    @Override
+    public void pumpDataEntries(DataEntryReader dataEntryReader) throws IOException {
+        Path modulesPath = jrtFileSystem.getPath("modules");
+        if (moduleName != null) {
+            Path moduleDir = modulesPath.resolve(moduleName);
+            if (!Files.isDirectory(moduleDir)) {
+                throw new IOException("Module '" + moduleName + "' does not exist");
+            }
+            processModuleFiles(moduleDir, dataEntryReader);
+        } else {
+            try (Stream<Path> moduleDirs = Files.list(modulesPath)) {
+                for (Path moduleDir : (Iterable<? extends Path>) moduleDirs::iterator) {
+                    processModuleFiles(moduleDir, dataEntryReader);
+                }
+            }
+        }
+    }
+
+    private void processModuleFiles(Path moduleDir, DataEntryReader dataEntryReader) throws IOException {
+        Files.walkFileTree(moduleDir, new SimpleFileVisitor<Path>() {
+            @Override
+            public @NotNull FileVisitResult visitFile(@NotNull Path file, @NotNull BasicFileAttributes attrs) throws IOException {
+                String name = moduleDir.relativize(file).toString();
+                dataEntryReader.read(new JrtDataEntry(file, name, attrs.size()));
+                return FileVisitResult.CONTINUE;
+            }
+        });
+    }
+
+    @Override
+    public void close() throws IOException {
+        jrtFileSystem.close();
+        // Note: Closing the class loader might not be thread-safe because by default the JDK caches the underlying
+        //   JarFile, so closing it implicitly here might affect other users of that jar
+        fallbackClassLoader.close();
+    }
+
+    /**
+     * Gets the path for the {@code jrt-fs.jar}.
+     */
+    public static Path getJrtFsJarPath(Path javaHome) {
+        return javaHome.resolve("lib").resolve("jrt-fs.jar");
+    }
+}


### PR DESCRIPTION
This is a proof-of-concept for using the `jrt:/` file system if a JDK does not have the `jmods` directory, see https://github.com/Guardsquare/proguard/issues/473#issuecomment-3378391090.

In theory the `jrt:/` file system could be used always, without having to rely on `jmods` files, but for now it is only implemented as fallback.

The classes `JrtDataEntrySource.java` and `JrtDataEntry.java` should probably be in proguard-core, but for convenience of this POC, I have included them here.

This is only a proof-of-concept, which seems to work, but I might have overlooked aspects of ProGuard, therefore this is probably not something which can be integrated as is. But feel free to take this as reference in case you want to implement this.