### PR TITLE
Remove java-test-fixtures to avoid  creating self references in published pom files

### DIFF
--- a/base/build.gradle
+++ b/base/build.gradle
@@ -1,6 +1,5 @@
 plugins {
     id 'java-library'
-    id 'java-test-fixtures'
     id 'maven-publish'
     id "org.jetbrains.kotlin.jvm"
     id 'com.adarshr.test-logger' version '4.0.0'

--- a/build.gradle
+++ b/build.gradle
@@ -115,19 +115,8 @@ allprojects { Project project ->
                 }
                 publishing {
                     publications {
-                        named(project.name) {
-                            def javaComponent = components.java as AdhocComponentWithVariants
-                            // java-test-fixtures creates issues ans self-references in pom files.
-                            // See https://github.com/gradle/gradle/issues/14936.
-                            from(javaComponent)
-                            if (pluginManager.hasPlugin("java-test-fixtures")) {
-                                javaComponent.withVariantsFromConfiguration(configurations.testFixturesApiElements) {
-                                    skip()
-                                }
-                                javaComponent.withVariantsFromConfiguration(configurations.testFixturesRuntimeElements) {
-                                    skip()
-                                }
-                            }
+                        getByName(project.name) {
+                            from(components.java)
                         }
                     }
                 }


### PR DESCRIPTION
Resolves #514 